### PR TITLE
Add agent readiness documentation and path-scoped rules

### DIFF
--- a/.claude/rules/app-interface.md
+++ b/.claude/rules/app-interface.md
@@ -1,0 +1,6 @@
+---
+paths:
+  - "internal/app_interface/**"
+---
+@docs/integration-guidelines.md
+@docs/security-guidelines.md

--- a/.claude/rules/ci-cd.md
+++ b/.claude/rules/ci-cd.md
@@ -1,0 +1,6 @@
+---
+paths:
+  - ".github/**"
+  - ".tekton/**"
+---
+@docs/security-guidelines.md

--- a/.claude/rules/config.md
+++ b/.claude/rules/config.md
@@ -1,0 +1,6 @@
+---
+paths:
+  - "internal/config/**"
+---
+@docs/security-guidelines.md
+@docs/error-handling-guidelines.md

--- a/.claude/rules/github-integration.md
+++ b/.claude/rules/github-integration.md
@@ -1,0 +1,7 @@
+---
+paths:
+  - "internal/git/github/**"
+---
+@docs/integration-guidelines.md
+@docs/api-contracts-guidelines.md
+@docs/testing-guidelines.md

--- a/.claude/rules/gitlab-integration.md
+++ b/.claude/rules/gitlab-integration.md
@@ -1,0 +1,7 @@
+---
+paths:
+  - "internal/git/gitlab/**"
+---
+@docs/integration-guidelines.md
+@docs/api-contracts-guidelines.md
+@docs/testing-guidelines.md

--- a/.claude/rules/llm.md
+++ b/.claude/rules/llm.md
@@ -1,0 +1,8 @@
+---
+paths:
+  - "internal/llm/**"
+---
+@docs/security-guidelines.md
+@docs/api-contracts-guidelines.md
+@docs/error-handling-guidelines.md
+@docs/performance-guidelines.md

--- a/.claude/rules/shared-git.md
+++ b/.claude/rules/shared-git.md
@@ -1,0 +1,6 @@
+---
+paths:
+  - "internal/git/shared/**"
+---
+@docs/integration-guidelines.md
+@docs/api-contracts-guidelines.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /.claude/
+!/.claude/rules/
+!/.claude/rules/**
 /.idea/
 /.env
 /rcs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,42 +31,6 @@ When working in a directory, read the guidelines listed for it:
 | `internal/app_interface/**` | integration, security |
 | `.github/**`, `.tekton/**` | security |
 
-## Code Quality Principles
-
-### Simplicity First
-- Write the simplest code that solves the problem.
-- Avoid abstractions until they are clearly needed (rule of three).
-- No helper functions for one-time operations.
-- No wrapper functions that just call another function.
-- Inline short logic instead of extracting unnecessary functions.
-
-### No Redundancy
-- Remove dead code immediately.
-- Do not store data that can be computed or already exists.
-- Do not rebuild values when you have them (e.g., do not reconstruct URLs from parts when you have the original URL).
-- Check if a function/variable is actually used before keeping it.
-- If data flows IN somewhere, do not create a method to pull it back OUT.
-
-### Avoid Over-Engineering
-- No premature optimization.
-- No "just in case" parameters or configurations.
-- No backward compatibility shims unless explicitly requested.
-- Do not add error handling for impossible scenarios.
-- Trust internal code; only validate at system boundaries.
-
-### Consistency
-- Use consistent naming across similar files (e.g., GitHub and GitLab implementations).
-- Match existing patterns in the codebase.
-- Same error message format across similar functions.
-- Same variable naming conventions.
-
-### Before Writing Code
-- Read existing code first to understand patterns.
-- Question whether the feature/change is needed.
-- Ask: "Is there a simpler way?"
-- Ask: "Does this data already exist somewhere?"
-- Ask: "Can I reuse existing code?"
-
 ## GitHub/GitLab Parity
 
 The `internal/git/github/` and `internal/git/gitlab/` packages implement the same `GitProvider` interface. When modifying one:
@@ -78,31 +42,6 @@ The `internal/git/github/` and `internal/git/gitlab/` packages implement the sam
 - Never add platform-specific fields to shared types in `internal/git/types/`.
 - Platform-agnostic logic belongs in `internal/git/shared/`, not in the platform packages.
 - When in doubt about whether a change should be mirrored, ask the user before proceeding.
-
-## Go Conventions
-
-### Naming
-- Use descriptive but concise names.
-- Match receiver variable to type (e.g., `d` for `documentationSource`).
-- Private functions/types use camelCase.
-- Only export what is needed.
-
-### Error Handling
-- Wrap errors with context: `fmt.Errorf("failed to X: %w", err)`.
-- Do not log AND return errors (pick one).
-- Fatal errors should return, not just log.
-- See [docs/error-handling-guidelines.md](docs/error-handling-guidelines.md) for detailed wrapping format, retry logic, and the warn-and-continue pattern.
-
-### Interfaces
-- Keep interfaces minimal (1-3 methods).
-- Name interfaces after what they do, not what they are.
-- Only create interfaces when you need abstraction.
-
-### Testing
-- Test behavior, not implementation.
-- Use table-driven tests for multiple cases.
-- Mock at boundaries (SDK clients, HTTP).
-- See [docs/testing-guidelines.md](docs/testing-guidelines.md) for the complete testing conventions.
 
 ## Architecture
 
@@ -203,16 +142,3 @@ The codebase has minimal direct dependencies (see `go.mod`):
 
 No web frameworks, no assertion libraries, no code generation tools, no mocking libraries.
 
-## Review Checklist
-
-Before submitting code, verify:
-
-- [ ] No unused imports, variables, or functions
-- [ ] No duplicate logic
-- [ ] No unnecessary helper functions
-- [ ] Consistent with existing codebase patterns
-- [ ] Error messages are clear and consistent
-- [ ] No over-engineered abstractions
-- [ ] Comments explain "why", not "what"
-- [ ] If modifying GitHub or GitLab code, the equivalent change is applied to the other platform (or confirmed as not applicable)
-- [ ] Relevant guideline files have been read for the directories being modified

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,218 @@
+# AGENTS.md
+
+Agent onboarding guide for the Release Confidence Score (RCS) codebase. This document covers cross-cutting conventions, architectural context, and pointers to domain-specific guidelines. It applies to all AI agents (Claude, Cursor, CodeRabbit, etc.).
+
+For project overview, operation modes, configuration, and environment variables, see [README.md](README.md).
+
+## Guideline Index
+
+Detailed domain-specific rules are maintained in separate guideline files. Read the relevant guidelines before modifying any code in their scope.
+
+| Guideline file | Domain |
+|---|---|
+| [docs/security-guidelines.md](docs/security-guidelines.md) | Authentication, credential handling, TLS, input validation |
+| [docs/performance-guidelines.md](docs/performance-guidelines.md) | Concurrency, caching, rate limiting, context propagation |
+| [docs/error-handling-guidelines.md](docs/error-handling-guidelines.md) | Error wrapping, custom types, retry logic, warn-and-continue |
+| [docs/api-contracts-guidelines.md](docs/api-contracts-guidelines.md) | GitProvider interface, SDK patterns, pagination, LLM clients |
+| [docs/testing-guidelines.md](docs/testing-guidelines.md) | Table-driven tests, mocking, assertion style, test parity |
+| [docs/integration-guidelines.md](docs/integration-guidelines.md) | GitHub/GitLab/GCP integration, shared logic, app-interface |
+
+### Path-to-Guideline Mapping
+
+When working in a directory, read the guidelines listed for it:
+
+| Path | Applicable guidelines |
+|---|---|
+| `internal/git/github/**` | integration, api-contracts, testing |
+| `internal/git/gitlab/**` | integration, api-contracts, testing |
+| `internal/git/shared/**` | integration, api-contracts |
+| `internal/llm/**` | security, api-contracts, error-handling, performance |
+| `internal/config/**` | security, error-handling |
+| `internal/app_interface/**` | integration, security |
+| `.github/**`, `.tekton/**` | security |
+
+## Code Quality Principles
+
+### Simplicity First
+- Write the simplest code that solves the problem.
+- Avoid abstractions until they are clearly needed (rule of three).
+- No helper functions for one-time operations.
+- No wrapper functions that just call another function.
+- Inline short logic instead of extracting unnecessary functions.
+
+### No Redundancy
+- Remove dead code immediately.
+- Do not store data that can be computed or already exists.
+- Do not rebuild values when you have them (e.g., do not reconstruct URLs from parts when you have the original URL).
+- Check if a function/variable is actually used before keeping it.
+- If data flows IN somewhere, do not create a method to pull it back OUT.
+
+### Avoid Over-Engineering
+- No premature optimization.
+- No "just in case" parameters or configurations.
+- No backward compatibility shims unless explicitly requested.
+- Do not add error handling for impossible scenarios.
+- Trust internal code; only validate at system boundaries.
+
+### Consistency
+- Use consistent naming across similar files (e.g., GitHub and GitLab implementations).
+- Match existing patterns in the codebase.
+- Same error message format across similar functions.
+- Same variable naming conventions.
+
+### Before Writing Code
+- Read existing code first to understand patterns.
+- Question whether the feature/change is needed.
+- Ask: "Is there a simpler way?"
+- Ask: "Does this data already exist somewhere?"
+- Ask: "Can I reuse existing code?"
+
+## GitHub/GitLab Parity
+
+The `internal/git/github/` and `internal/git/gitlab/` packages implement the same `GitProvider` interface. When modifying one:
+
+- Check if the same change applies to the other platform.
+- Keep function signatures, error messages, and behavior consistent.
+- If a fix applies to one platform, it likely applies to both (e.g., URL regex fixes).
+- Both packages have mirrored file structures: `client.go`, `diff.go`, `user_guidance.go`, `documentation_source.go`, `release_data_fetcher.go`.
+- Never add platform-specific fields to shared types in `internal/git/types/`.
+- Platform-agnostic logic belongs in `internal/git/shared/`, not in the platform packages.
+- When in doubt about whether a change should be mirrored, ask the user before proceeding.
+
+## Go Conventions
+
+### Naming
+- Use descriptive but concise names.
+- Match receiver variable to type (e.g., `d` for `documentationSource`).
+- Private functions/types use camelCase.
+- Only export what is needed.
+
+### Error Handling
+- Wrap errors with context: `fmt.Errorf("failed to X: %w", err)`.
+- Do not log AND return errors (pick one).
+- Fatal errors should return, not just log.
+- See [docs/error-handling-guidelines.md](docs/error-handling-guidelines.md) for detailed wrapping format, retry logic, and the warn-and-continue pattern.
+
+### Interfaces
+- Keep interfaces minimal (1-3 methods).
+- Name interfaces after what they do, not what they are.
+- Only create interfaces when you need abstraction.
+
+### Testing
+- Test behavior, not implementation.
+- Use table-driven tests for multiple cases.
+- Mock at boundaries (SDK clients, HTTP).
+- See [docs/testing-guidelines.md](docs/testing-guidelines.md) for the complete testing conventions.
+
+## Architecture
+
+### High-Level Data Flow
+
+```
+main.go
+  -> cli.Parse()           -- parse flags, determine mode
+  -> config.Load()         -- load + validate env vars
+  -> internal.New()        -- create ReleaseAnalyzer (GitHub client, GitLab client, GCP OAuth2, LLM client)
+  -> AnalyzeAppInterface() or AnalyzeStandalone()
+       -> getReleaseData() -- parallel fetch from GitHub/GitLab via GitProvider interface
+       -> analyze()        -- format data, call LLM, retry with truncation if needed, render report
+```
+
+### Package Layout
+
+```
+main.go                           -- Entry point; CLI dispatch, fatal error handling
+internal/
+  release_analyzer.go             -- Orchestrator: wires providers, runs analysis, handles LLM retry
+  cli/                            -- CLI flag parsing and validation
+  config/                         -- Environment variable loading and validation
+  logger/                         -- slog setup (text/JSON, log level)
+  git/
+    types/                        -- Platform-agnostic interfaces (GitProvider, DocumentationSource) and data types
+    github/                       -- GitHub GitProvider implementation
+    gitlab/                       -- GitLab GitProvider implementation (mirrors github/ structure)
+    shared/                       -- Cross-platform logic: documentation fetching, QE labels, user guidance parsing, external URL fetching
+  llm/
+    providers/                    -- LLM client implementations (Claude, Gemini) + factory
+    errors/                       -- ContextWindowError custom type
+    formatting/                   -- Format comparisons and documentation for the LLM prompt
+    prompts/system/               -- Embedded system prompt markdown files + version selector
+    prompts/user/                 -- User prompt template rendering
+    truncation/                   -- Progressive diff truncation with risk-based file prioritization
+  http/                           -- HTTP client factory (timeout, TLS skip)
+  report/                         -- Report template rendering
+  app_interface/                  -- App-interface mode: GitLab MR note parsing, diff URL extraction, report posting
+```
+
+### Key Interfaces
+
+There are two core interfaces that define the extension points:
+
+- **`GitProvider`** (`internal/git/types/interfaces.go`): Three methods -- `IsCompareURL`, `FetchReleaseData`, `Name`. Implemented by `github.Fetcher` and `gitlab.Fetcher`.
+- **`LLMClient`** (`internal/llm/providers/interface.go`): Single method -- `Analyze(userPrompt string) (string, error)`. Implemented by `claude` and `gemini` providers.
+
+A third interface, **`DocumentationSource`**, decouples documentation fetching from platform SDKs with `GetDefaultBranch` and `FetchFileContent`.
+
+### Embedded Files
+
+Several files are embedded at compile time via `//go:embed`:
+
+- `internal/llm/prompts/system/system_prompt_v1.md` and `system_prompt_v2.md` -- LLM system prompts
+- `internal/llm/prompts/user/user_prompt_template_v1.md` -- User prompt Go template
+- `internal/report/report_template.md` -- Report output Go template
+- `internal/llm/truncation/truncation.go` embeds a JSON file for file risk classification
+
+Modifying these embedded files changes LLM behavior or report output. Test changes carefully.
+
+### Two Operation Modes
+
+- **App-interface mode**: Reads a GitLab MR from the `service/app-interface` project, extracts diff URLs from a `devtools-bot` comment, fetches release data from those URLs, and optionally posts the report back to the MR.
+- **Standalone mode**: Takes compare URLs directly via CLI flags and prints the report to stdout.
+
+Both modes converge at `analyze()` in `release_analyzer.go`.
+
+### Concurrency Model
+
+The codebase uses a two-tier parallelism pattern with `errgroup`:
+
+1. **Top level**: Multiple compare URLs are fetched in parallel (one goroutine per URL, no concurrency limit).
+2. **Per-URL level**: Within each URL, diff+guidance and documentation run as two parallel errgroup goroutines. Diff and guidance are sequential within their goroutine because guidance depends on diff results.
+
+API-heavy loops (commit enrichment) use `g.SetLimit(10)` to cap concurrent API calls. Do not add a third tier of nesting.
+
+### Configuration
+
+All configuration comes from `RCS_`-prefixed environment variables, loaded and validated in `config.Load()` at startup. There are no config files, no YAML, no flags for configuration values. CLI flags control only the operation mode and input parameters.
+
+### Build and CI
+
+- **Build**: `go build -o rcs .` or `docker compose build`. Static binary with `CGO_ENABLED=0`.
+- **Tests**: `go test ./...`. No build tags, test flags, or special setup required.
+- **GitHub Actions** (`.github/workflows/go.yml`): Runs build and test on push/PR to main. Actions are pinned to commit SHAs.
+- **Tekton** (`.tekton/`): Konflux/RHTAP pipelines for container image builds. Hermetic builds, scoped service accounts, versioned pipeline references.
+- **Renovate** (`renovate.json`): Automated dependency updates via Konflux mintmaker config. Tekton updates auto-merge.
+
+### Dependencies
+
+The codebase has minimal direct dependencies (see `go.mod`):
+
+- `github.com/google/go-github/v86` -- GitHub API SDK
+- `gitlab.com/gitlab-org/api/client-go/v2` -- GitLab API SDK
+- `golang.org/x/oauth2` -- GCP OAuth2 token source
+- `golang.org/x/sync` -- errgroup for structured concurrency
+
+No web frameworks, no assertion libraries, no code generation tools, no mocking libraries.
+
+## Review Checklist
+
+Before submitting code, verify:
+
+- [ ] No unused imports, variables, or functions
+- [ ] No duplicate logic
+- [ ] No unnecessary helper functions
+- [ ] Consistent with existing codebase patterns
+- [ ] Error messages are clear and consistent
+- [ ] No over-engineered abstractions
+- [ ] Comments explain "why", not "what"
+- [ ] If modifying GitHub or GitLab code, the equivalent change is applied to the other platform (or confirmed as not applicable)
+- [ ] Relevant guideline files have been read for the directories being modified

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,20 +17,6 @@ Detailed domain-specific rules are maintained in separate guideline files. Read 
 | [docs/testing-guidelines.md](docs/testing-guidelines.md) | Table-driven tests, mocking, assertion style, test parity |
 | [docs/integration-guidelines.md](docs/integration-guidelines.md) | GitHub/GitLab/GCP integration, shared logic, app-interface |
 
-### Path-to-Guideline Mapping
-
-When working in a directory, read the guidelines listed for it:
-
-| Path | Applicable guidelines |
-|---|---|
-| `internal/git/github/**` | integration, api-contracts, testing |
-| `internal/git/gitlab/**` | integration, api-contracts, testing |
-| `internal/git/shared/**` | integration, api-contracts |
-| `internal/llm/**` | security, api-contracts, error-handling, performance |
-| `internal/config/**` | security, error-handling |
-| `internal/app_interface/**` | integration, security |
-| `.github/**`, `.tekton/**` | security |
-
 ## Code Quality Principles
 
 - Write the simplest code that solves the problem. Avoid abstractions until clearly needed (rule of three).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,14 @@ When working in a directory, read the guidelines listed for it:
 | `internal/app_interface/**` | integration, security |
 | `.github/**`, `.tekton/**` | security |
 
+## Code Quality Principles
+
+- Write the simplest code that solves the problem. Avoid abstractions until clearly needed (rule of three).
+- Remove dead code immediately. Check if a function/variable is actually used before keeping it.
+- Do not store data that can be computed or already exists. Do not rebuild values when you have them (e.g., do not reconstruct URLs from parts when you have the original URL).
+- If data flows IN somewhere, do not create a method to pull it back OUT.
+- Trust internal code; only validate at system boundaries. Do not add error handling for impossible scenarios.
+
 ## GitHub/GitLab Parity
 
 The `internal/git/github/` and `internal/git/gitlab/` packages implement the same `GitProvider` interface. When modifying one:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,78 +1,58 @@
-# Claude Code Guidelines
+# Claude Code Instructions
 
-## Code Quality Principles
+@AGENTS.md
 
-### Simplicity First
-- Write the simplest code that solves the problem
-- Avoid abstractions until they're clearly needed (rule of three)
-- No helper functions for one-time operations
-- No wrapper functions that just call another function
-- Inline short logic instead of extracting unnecessary functions
+## Build and Test Commands
 
-### No Redundancy
-- Remove dead code immediately
-- Don't store data that can be computed or already exists
-- Don't rebuild values when you have them (e.g., don't reconstruct URLs from parts when you have the original URL)
-- Check if a function/variable is actually used before keeping it
-- If data flows IN somewhere, don't create a method to pull it back OUT
+### Build
+```bash
+go build -v ./...
+```
 
-### Avoid Over-Engineering
-- No premature optimization
-- No "just in case" parameters or configurations
-- No backward compatibility shims unless explicitly requested
-- Don't add error handling for impossible scenarios
-- Trust internal code; only validate at system boundaries
+Or build the binary directly:
+```bash
+go build -o rcs .
+```
 
-### Consistency
-- Use consistent naming across similar files (e.g., GitHub and GitLab implementations)
-- Match existing patterns in the codebase
-- Same error message format across similar functions
-- Same variable naming conventions
+### Test
+```bash
+go test -v ./...
+```
 
-### GitHub/GitLab Parity
-The `git/github/` and `git/gitlab/` packages implement the same `GitProvider` interface. When modifying one:
-- Check if the same change applies to the other platform
-- Keep function signatures, error messages, and behavior consistent
-- If a fix applies to one platform, it likely applies to both (e.g., URL regex fixes)
-- When in doubt about whether a change should be mirrored, ask the user before proceeding
+### Docker Build
+```bash
+docker compose build
+```
 
-### Before Writing Code
-- Read existing code first to understand patterns
-- Question whether the feature/change is needed
-- Ask: "Is there a simpler way?"
-- Ask: "Does this data already exist somewhere?"
-- Ask: "Can I reuse existing code?"
+### Run Locally
+```bash
+# Copy and configure environment
+cp .env.example .env
+# Edit .env with credentials
 
-## Go-Specific Guidelines
+# Run with Docker
+docker compose run --rm rcs --compare-links "https://github.com/org/repo/compare/v1.0...v1.1"
 
-### Naming
-- Use descriptive but concise names
-- Match receiver variable to type (e.g., `d` for `documentationSource`)
-- Private functions/types use camelCase
-- Only export what's needed
+# Or run the binary directly (after setting environment variables)
+./rcs --compare-links "https://github.com/org/repo/compare/v1.0...v1.1"
+```
 
-### Error Handling
-- Wrap errors with context: `fmt.Errorf("failed to X: %w", err)`
-- Don't log AND return errors (pick one)
-- Fatal errors should return, not just log
+## Claude Code Behavior
 
-### Interfaces
-- Keep interfaces minimal (1-3 methods)
-- Name interfaces after what they do, not what they are
-- Only create interfaces when you need abstraction
+### Path-Specific Rules
+The `.claude/rules/` directory contains path-based rule imports that automatically load relevant guidelines:
+- `github-integration.md` - Loads integration, api-contracts, testing guidelines for `internal/git/github/**`
+- `gitlab-integration.md` - Loads integration, api-contracts, testing guidelines for `internal/git/gitlab/**`
+- `shared-git.md` - Loads integration, api-contracts guidelines for `internal/git/shared/**`
+- `llm.md` - Loads security, api-contracts, error-handling, performance guidelines for `internal/llm/**`
+- `config.md` - Loads security, error-handling guidelines for `internal/config/**`
+- `app-interface.md` - Loads integration, security guidelines for `internal/app_interface/**`
+- `ci-cd.md` - Loads security guidelines for `.github/**` and `.tekton/**`
 
-### Testing
-- Test behavior, not implementation
-- Use table-driven tests for multiple cases
-- Mock at boundaries (SDK clients, HTTP)
+These rules are automatically applied when you work in those directories.
 
-## Review Checklist
-
-Before submitting code, verify:
-- [ ] No unused imports, variables, or functions
-- [ ] No duplicate logic
-- [ ] No unnecessary helper functions
-- [ ] Consistent with existing codebase patterns
-- [ ] Error messages are clear and consistent
-- [ ] No over-engineered abstractions
-- [ ] Comments explain "why", not "what"
+### Environment Requirements
+- Go 1.25.0 or later
+- No pre-commit hooks configured
+- No linter configuration (follow Go standard formatting)
+- No vendoring (dependencies via `go mod download`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,20 +37,6 @@ docker compose run --rm rcs --compare-links "https://github.com/org/repo/compare
 ./rcs --compare-links "https://github.com/org/repo/compare/v1.0...v1.1"
 ```
 
-## Claude Code Behavior
-
-### Path-Specific Rules
-The `.claude/rules/` directory contains path-based rule imports that automatically load relevant guidelines:
-- `github-integration.md` - Loads integration, api-contracts, testing guidelines for `internal/git/github/**`
-- `gitlab-integration.md` - Loads integration, api-contracts, testing guidelines for `internal/git/gitlab/**`
-- `shared-git.md` - Loads integration, api-contracts guidelines for `internal/git/shared/**`
-- `llm.md` - Loads security, api-contracts, error-handling, performance guidelines for `internal/llm/**`
-- `config.md` - Loads security, error-handling guidelines for `internal/config/**`
-- `app-interface.md` - Loads integration, security guidelines for `internal/app_interface/**`
-- `ci-cd.md` - Loads security guidelines for `.github/**` and `.tekton/**`
-
-These rules are automatically applied when you work in those directories.
-
 ### Environment Requirements
 - Go 1.25.0 or later
 - No pre-commit hooks configured

--- a/docs/api-contracts-guidelines.md
+++ b/docs/api-contracts-guidelines.md
@@ -1,0 +1,127 @@
+# API Contracts Guidelines
+
+## GitProvider Interface
+
+The `GitProvider` interface (`internal/git/types/interfaces.go`) is the central abstraction for all git platform interactions. Every platform must implement exactly three methods:
+
+- `IsCompareURL(url string) bool` -- URL detection via compiled regex (no network calls)
+- `FetchReleaseData(ctx context.Context, compareURL string) (*Comparison, []UserGuidance, *Documentation, error)` -- single entry point that returns all data
+- `Name() string` -- returns platform display name ("GitHub" or "GitLab")
+
+Rules:
+1. `FetchReleaseData` must return all three data types in one call. Callers never call sub-fetchers directly.
+2. The caller dispatches by iterating providers and calling `IsCompareURL` -- never by parsing the URL itself.
+3. New providers must follow the same `Fetcher` struct pattern: hold an SDK client and `*config.Config`.
+
+## Compare URL Regex Patterns
+
+GitHub and GitLab use different regex patterns. Both must:
+- Anchor refs with `(.+?)\.\.\.([^?#]+)` to handle tags, branches, and SHAs
+- Strip query strings and fragments from the head ref via `[^?#]+`
+
+Key differences:
+- GitHub regex captures `owner` and `repo` separately; GitLab captures `host` and full `projectPath` (supports nested groups like `group/subgroup/repo`)
+- GitHub regex is end-anchored (`$`); GitLab is not (allows trailing path segments)
+- GitLab includes `/-/` in the path; GitHub does not
+- Both regexes are compiled at package level (`var ... = regexp.MustCompile(...)`)
+
+When fixing a regex issue in one provider, check whether the same fix applies to the other.
+
+## SDK Client Construction
+
+GitHub and GitLab SDK clients are created differently:
+
+- **GitHub**: `github.NewClient(nil).WithAuthToken(token)` -- no error return, no base URL needed
+- **GitLab**: `gitlab.NewClient(token, gitlab.WithBaseURL(...))` -- returns `(*Client, error)`, requires base URL, optionally accepts custom `http.Client` for SSL skip
+
+Both are constructed in a `client.go` file within their package. The HTTP client for SSL override comes from `internal/http/httpclient.go`, never built inline.
+
+## LLM Provider Pattern
+
+LLM providers implement `LLMClient` with a single method: `Analyze(userPrompt string) (string, error)`.
+
+Conventions every provider must follow:
+1. Build endpoint URL from `cfg.ModelAPI` + provider-specific path suffix
+2. Create `http.Client` via `httputil.NewHTTPClient` with timeout from `cfg.ModelTimeoutSeconds`
+3. Authenticate with GCP OAuth2: call `tokenSource.Token()`, set `Authorization: Bearer` header
+4. On non-200 response, check `llmerrors.IsContextWindowError` first; if true, return `*llmerrors.ContextWindowError`. Otherwise return `fmt.Errorf("API error %d: %s", ...)`
+5. Log token usage at Debug level after successful response
+6. Use `Temperature: 0` for deterministic output
+7. Request/response types are provider-specific structs defined in the same file (not shared)
+
+Provider differences:
+- Claude sends system prompt as a separate `system` field; Gemini concatenates system+user into a single message
+- Claude response is `Content[0].Text`; Gemini response is `Choices[0].Message.Content`
+
+## HTTP Client Factory
+
+All HTTP clients must be created via `httputil.NewHTTPClient(HTTPClientOptions{...})` from `internal/http/httpclient.go`. Never construct `http.Client{}` directly. The factory handles:
+- Timeout configuration
+- TLS skip (only configures custom transport when `SkipSSLVerify` is true)
+
+## Pagination
+
+### GitHub
+Use `github.ListOptions{Page: 1, PerPage: 100}` and loop until `resp.NextPage == 0`:
+
+```go
+for {
+    items, resp, err := fetcher(ctx, opts)
+    // ...
+    if resp.NextPage == 0 { break }
+    opts.Page = resp.NextPage
+}
+```
+
+The generic helper `fetchAllPaginated[T]` in `github/user_guidance.go` encapsulates this. Use it for any paginated GitHub endpoint. For the comparison endpoint specifically, pagination is handled in `fetchComparisonWithPagination` because it needs to preserve the first page's metadata.
+
+### GitLab
+Same loop structure but with `gitlab.ListOptions{PerPage: 100, Page: 1}`. GitLab has no generic helper -- pagination is inlined. When adding new paginated GitLab calls, follow the existing inline pattern in `user_guidance.go` and `app_interface.go`.
+
+## Concurrency and Rate Limiting
+
+1. Use `errgroup.WithContext(ctx)` for all parallel API work
+2. Set `g.SetLimit(10)` when making per-commit API calls to avoid rate limiting
+3. Use a thread-safe cache (`sync.RWMutex` + map) to deduplicate PR/MR fetches. GitHub uses `prCache`; GitLab uses `mrCache`. Both follow the same `getOrFetchX` pattern: read-lock check, then write-lock store
+4. Log `rate_limit_remaining` from GitHub responses at Debug level
+5. Independent data fetches (e.g., documentation vs. diff+guidance) run in parallel goroutines via errgroup. Sequential dependencies (guidance depends on diff) run within the same goroutine
+
+## Platform-Agnostic Types
+
+All API responses must be converted to types in `internal/git/types/types.go` before leaving the platform package:
+- GitHub `CommitFile` -> `types.FileChange` via `convertFile()`
+- GitLab `Diff` -> `types.FileChange` via `convertDiff()`
+- Both use status strings: `"added"`, `"modified"`, `"removed"`, `"renamed"`
+
+GitLab does not provide per-file addition/deletion counts, so `parsePatchStats()` calculates them from the unified diff. GitHub provides these directly via the SDK.
+
+## DocumentationSource Interface
+
+The `DocumentationSource` interface decouples documentation fetching from platform SDKs:
+- `GetDefaultBranch(ctx) (string, error)` -- falls back to `"main"` if the repo has no default branch
+- `FetchFileContent(ctx, path, ref) (string, error)` -- GitHub SDK auto-decodes base64; GitLab requires manual `base64.StdEncoding.DecodeString` when `file.Encoding == "base64"`
+
+## External URL Fetching
+
+When fetching raw content from external URLs (`shared/external_url_fetcher.go`):
+1. Detect GitLab URLs via hostname parsing (not regex) to decide SSL and auth behavior
+2. Add `PRIVATE-TOKEN` header for GitLab URLs (not `Authorization: Bearer`)
+3. Use a fixed 30-second timeout for external fetches, separate from LLM timeout
+
+Blob-to-raw URL conversion (`shared/documentation_fetcher.go`):
+- Convert blob URLs to raw URLs via `strings.Replace(path, "/blob/", "/raw/", 1)` in `fetchAdditionalDocContent` -- works for both GitHub and GitLab URL formats
+
+## Authorization Checks
+
+GitHub and GitLab use different authorization models for user guidance:
+- **GitHub**: PR author OR user with `APPROVED` review AND `AuthorAssociation` in `{OWNER, MEMBER, COLLABORATOR}`. Requires fetching reviews via API
+- **GitLab**: MR author OR user in MR approvers list (fetched via `MergeRequestApprovals.GetConfiguration`). No association check needed because GitLab's approval system is permission-gated
+- **App-interface**: All guidance is `IsAuthorized: true` (trusted context)
+
+## Configuration and Authentication
+
+1. All config comes from environment variables prefixed with `RCS_`. Model-specific vars use the provider name: `RCS_CLAUDE_MODEL_API`, `RCS_GEMINI_MODEL_API`
+2. GCP service account key is base64-encoded in `RCS_GOOGLE_SA_KEY_B64`, decoded once, used to create `oauth2.TokenSource`, then cleared from memory
+3. GitHub auth: token passed to SDK via `WithAuthToken()`
+4. GitLab auth: token passed to SDK constructor. For raw HTTP calls, use `PRIVATE-TOKEN` header
+5. GitLab requires `RCS_GITLAB_BASE_URL` when `RCS_GITLAB_TOKEN` is set

--- a/docs/error-handling-guidelines.md
+++ b/docs/error-handling-guidelines.md
@@ -1,0 +1,203 @@
+# Error Handling Guidelines
+
+## Core Rule: Return Errors, Don't Log Them
+
+This codebase follows a strict "return, don't log" policy. Errors propagate up the call stack and are handled at exactly one place: `main.go` calls `log.Fatalf`. Internal packages never call `log.Fatal` or `log.Fatalf`.
+
+The only logging related to errors within internal packages is `slog.Warn` for **non-fatal degradations** (see "Warn-and-Continue" below).
+
+## Error Wrapping Format
+
+All errors use `fmt.Errorf` with `%w` and a short, lowercase, verb-first context prefix:
+
+```go
+return fmt.Errorf("failed to fetch comparison: %w", err)
+```
+
+**Prefix conventions by layer:**
+- API/SDK calls: `"failed to <verb> <noun>: %w"` -- e.g., `"failed to get PR #%d: %w"`
+- HTTP operations: short noun prefix -- `"marshal request: %w"`, `"read response: %w"`, `"http request: %w"`
+- Parsing: `"invalid <format> format: %s"` with the bad input value appended
+
+Never include the function name in the error message. The verb-noun prefix provides enough context for tracing.
+
+## Config Validation Errors
+
+Config validation uses a distinct pattern: errors name the environment variable and show the invalid value.
+
+```go
+return fmt.Errorf("%s must be a valid integer, got: %s", key, str)
+return fmt.Errorf("%s must be between %d and %d, got: %d", key, min, max, val)
+return fmt.Errorf("RCS_LOG_FORMAT must be one of: %v; got: %s", validLogFormats, cfg.LogFormat)
+```
+
+Rules:
+- Required-but-missing variables: `"<VAR_NAME> environment variable is required"`
+- Invalid values: `"<VAR_NAME> must be <constraint>, got: <value>"`
+- Cross-field validation: describe both fields and their values
+- `config.Load()` returns `nil, err` on any validation failure; callers never see a partial config
+
+## Custom Error Type: ContextWindowError
+
+The only custom error type is `ContextWindowError` in `internal/llm/errors/`. It represents LLM context window overflow and enables retry logic.
+
+**Structure:**
+```go
+type ContextWindowError struct {
+    StatusCode int
+    Message    string
+    Provider   string   // "Claude" or "Gemini"
+}
+```
+
+**Detection pattern (used identically in both LLM providers):**
+```go
+if llmerrors.IsContextWindowError(resp.StatusCode, body) {
+    return "", &llmerrors.ContextWindowError{
+        StatusCode: resp.StatusCode,
+        Message:    string(body),
+        Provider:   "Claude",
+    }
+}
+return "", fmt.Errorf("API error %d: %s", resp.StatusCode, string(body))
+```
+
+**Consumption via type assertion (not `errors.As`):**
+```go
+contextErr, ok := err.(*llmerrors.ContextWindowError)
+if !ok {
+    return 0, "", fmt.Errorf("failed to analyze: %w", err)
+}
+```
+
+When adding new custom error types, follow this pattern: struct with exported fields, detection helper (`IsXxxError`), and type assertion at the call site.
+
+## Retry Logic
+
+Retry exists only for context window errors, using progressive truncation levels: low -> moderate -> high -> extreme.
+
+Rules:
+- On `ContextWindowError`: log a warning, try the next truncation level
+- On any other error during retry: fail immediately with wrapping
+- After exhausting all levels: wrap the last error with `"failed to analyze even with extreme truncation: %w"`
+
+```go
+if _, isContextErr := err.(*llmerrors.ContextWindowError); isContextErr {
+    lastErr = err
+    continue    // try next truncation level
+}
+return "", nil, fmt.Errorf("failed to analyze with %s truncation: %w", level, err)
+```
+
+There is no general-purpose retry, backoff, or circuit breaker in this codebase.
+
+## Concurrent Error Handling with errgroup
+
+All parallel work uses `golang.org/x/sync/errgroup`. The pattern is consistent across the codebase:
+
+```go
+g, gCtx := errgroup.WithContext(ctx)
+
+g.Go(func() error {
+    result, err := doWork(gCtx, ...)
+    if err != nil {
+        return fmt.Errorf("failed to do work: %w", err)
+    }
+    mu.Lock()
+    defer mu.Unlock()
+    results = append(results, result)
+    return nil
+})
+
+if err := g.Wait(); err != nil {
+    return nil, err
+}
+```
+
+Rules:
+- Always pass `gCtx` (the errgroup context) to work inside `g.Go`
+- Use `g.SetLimit(10)` for API-calling goroutines to avoid rate limiting
+- Protect shared slices with `sync.Mutex` when multiple goroutines append
+- When goroutines fetch data needed later (e.g., comments after `g.Wait()`), use the original `ctx`, not `gCtx` which is canceled after `Wait()` returns
+
+## Warn-and-Continue Pattern
+
+Some errors are intentionally non-fatal. The codebase uses `slog.Warn` + early return (not error propagation) when:
+
+1. **Enrichment fails for a single item in a batch** -- e.g., failing to find a PR/MR for one commit should not abort the entire comparison:
+   ```go
+   prNumber, err := getPRForCommit(ctx, client, owner, repo, entry.SHA)
+   if err != nil {
+       slog.Warn("Failed to find PR for commit", "commit", entry.ShortSHA, "error", err)
+       return entry
+   }
+   ```
+
+2. **Optional data is missing** -- e.g., documentation file not found:
+   ```go
+   mainDocContent, err := d.source.FetchFileContent(ctx, mainDocFilename, defaultBranch)
+   if err != nil {
+       slog.Debug("No main documentation file found", "repo", repository.URL, "error", err)
+       return &types.Documentation{Repository: repository}, nil
+   }
+   ```
+
+3. **Additional documentation fetch fails** -- tracked in `failedDocs` map for reporting, but processing continues.
+
+The rule: if the operation is supplementary and the caller can produce a useful result without it, warn and continue. If the operation is required for the caller to function, return the error.
+
+## Sensitive Data in Errors
+
+Authentication token errors intentionally omit the underlying error to avoid leaking credential details:
+
+```go
+tok, err := c.tokenSource.Token()
+if err != nil {
+    return "", fmt.Errorf("failed to obtain authentication token")  // No %w
+}
+```
+
+GCP credential parsing follows the same rule. After a credential error, the raw key bytes are zeroed and nilled before returning.
+
+## Panic Usage
+
+`panic` is used in exactly one place: the `init()` function in `truncation.go` when an embedded JSON file fails to parse. This is acceptable because:
+- The file is embedded at compile time
+- A parse failure indicates a programming error
+- It will be caught during development, never in production
+
+Do not add new `panic` calls. All runtime errors should be returned.
+
+## errgroup Goroutines That Never Return Errors
+
+In `diff.go` (both GitHub and GitLab), commit augmentation goroutines always return `nil`:
+
+```go
+g.Go(func() error {
+    comparison.Commits[i] = buildCommitEntry(gCtx, client, commit, owner, repo, cache)
+    return nil
+})
+```
+
+This is intentional. `buildCommitEntry` handles its own errors via warn-and-continue, returning partial data. The errgroup is used purely for concurrency control (`g.SetLimit(10)`), not error propagation.
+
+## GitHub/GitLab Error Message Parity
+
+Error messages for equivalent operations must match across platforms, differing only in platform-specific terminology:
+
+| GitHub | GitLab |
+|--------|--------|
+| `"failed to get PR #%d: %w"` | `"failed to get MR !%d: %w"` |
+| `"failed to find PRs for commit %s: %w"` | `"failed to get MRs for commit %s: %w"` |
+
+When adding error handling to one platform, add the equivalent to the other.
+
+## CLI Validation Errors
+
+CLI validation errors include actionable help text:
+
+```go
+return fmt.Errorf("standalone mode requires compare URLs\n\nTry:\n  rcs --compare-links <url1>,<url2>\n\nOr run 'rcs --help' for more information")
+```
+
+This pattern applies only to user-facing CLI argument errors, not to internal errors.

--- a/docs/error-handling-guidelines.md
+++ b/docs/error-handling-guidelines.md
@@ -62,6 +62,8 @@ if llmerrors.IsContextWindowError(resp.StatusCode, body) {
 return "", fmt.Errorf("API error %d: %s", resp.StatusCode, string(body))
 ```
 
+Note: the full response body is included in error messages. This is acceptable because LLM API error responses are short JSON payloads, not large documents. If adding error handling for endpoints that may return large bodies, truncate before including in errors.
+
 **Consumption via type assertion (not `errors.As`):**
 ```go
 contextErr, ok := err.(*llmerrors.ContextWindowError)
@@ -194,10 +196,4 @@ When adding error handling to one platform, add the equivalent to the other.
 
 ## CLI Validation Errors
 
-CLI validation errors include actionable help text:
-
-```go
-return fmt.Errorf("standalone mode requires compare URLs\n\nTry:\n  rcs --compare-links <url1>,<url2>\n\nOr run 'rcs --help' for more information")
-```
-
-This pattern applies only to user-facing CLI argument errors, not to internal errors.
+CLI validation errors include actionable help text (e.g., `"standalone mode requires compare URLs\n\nTry:\n  rcs --compare-links ..."`). This pattern applies only to user-facing CLI argument errors, not to internal errors.

--- a/docs/integration-guidelines.md
+++ b/docs/integration-guidelines.md
@@ -1,0 +1,99 @@
+# Integration Guidelines
+
+## Architecture Overview
+
+This codebase integrates with GitHub, GitLab, GCP Vertex AI (Claude and Gemini), and external URLs. All git platform integrations implement the `GitProvider` interface (`internal/git/types/interfaces.go`), and all LLM integrations implement the `LLMClient` interface (`internal/llm/providers/interface.go`).
+
+## Git Platform Parity (GitHub / GitLab)
+
+The `internal/git/github/` and `internal/git/gitlab/` packages mirror each other structurally. Every file in one package has an equivalent in the other:
+
+| Concern | GitHub file | GitLab file |
+|---|---|---|
+| SDK client creation | `client.go` | `client.go` |
+| Diff fetching + commit augmentation | `diff.go` | `diff.go` |
+| User guidance extraction | `user_guidance.go` | `user_guidance.go` |
+| Documentation source | `documentation_source.go` | `documentation_source.go` |
+| Orchestration | `release_data_fetcher.go` | `release_data_fetcher.go` |
+
+Rules:
+- Both platforms use the same `types.Comparison`, `types.UserGuidance`, and `types.Documentation` structs. Never add platform-specific fields to shared types.
+- Both use a thread-safe cache (`prCache` / `mrCache`) with `sync.RWMutex` to deduplicate PR/MR API calls across commit augmentation and user guidance. When adding new cached resources, follow this same pattern.
+- Both use `errgroup.WithContext` with `g.SetLimit(10)` for parallel commit augmentation. Keep the concurrency limit at 10 to avoid API rate limiting.
+- Both use `shared.ExtractQELabel()` and `shared.ParseUserGuidance()` for cross-platform logic. Put platform-agnostic logic in `internal/git/shared/`, not in the platform packages.
+- Error message format differs by platform: GitHub uses `"PR #%d"`, GitLab uses `"MR !%d"`. Keep this convention.
+
+## GitHub SDK Conventions
+
+- SDK: `github.com/google/go-github/v86/github`. Import alias: `githubapi` in `release_data_fetcher.go`, bare `github` in other files.
+- Client creation: `github.NewClient(nil).WithAuthToken(cfg.GitHubToken)` -- no custom HTTP client needed. Token comes from `RCS_GITHUB_TOKEN`.
+- Compare URL regex: `githubCompareRegex` anchored with `$` at end. Extracts exactly 4 groups: owner, repo, base, head.
+- Pagination: Use `fetchAllPaginated[T]` generic helper for list endpoints (comments, reviews). Use manual pagination loop for `CompareCommits` (which returns a composite object, not a list).
+- Always use `GetXxx()` safe accessors on GitHub SDK objects (e.g., `commit.GetSHA()`, `pr.GetNumber()`). Never dereference pointers directly.
+- Authorization check: PR author OR approved reviewer with `AuthorAssociation` in `{OWNER, MEMBER, COLLABORATOR}`.
+
+## GitLab SDK Conventions
+
+- SDK: `gitlab.com/gitlab-org/api/client-go/v2`. Import alias: `gitlabapi` in `release_data_fetcher.go` and `app_interface.go`, bare `gitlab` in other files.
+- Client creation requires `gitlab.WithBaseURL(cfg.GitLabBaseURL)`. The base URL (`RCS_GITLAB_BASE_URL`) is mandatory when a GitLab token is provided.
+- SSL skip: only the GitLab client supports `SkipSSLVerify`. When enabled, pass a custom `*http.Client` via `gitlab.WithHTTPClient()`.
+- Project path must be URL-encoded via `url.PathEscape()` for all API calls. Do this once and pass the encoded path to downstream functions.
+- Context passing: use `gitlab.WithContext(ctx)` as the last argument to every SDK call. This is a functional option, not a field on the options struct.
+- Compare URL regex: `gitlabCompareRegex` is NOT anchored at end (allows query params). Supports nested groups (`group/subgroup/repo`).
+- GitLab diffs don't include per-file stats. `parsePatchStats()` in `diff.go` counts `+`/`-` lines from the unified diff, skipping `+++`/`---` headers.
+- Authorization check: MR author OR user in `MergeRequestApprovals.GetConfiguration()` approvers list.
+
+## GCP OAuth2 Authentication
+
+All LLM calls go through GCP Vertex AI. Authentication flow in `release_analyzer.go`:
+
+1. `RCS_GOOGLE_SA_KEY_B64` env var contains base64-encoded GCP service account JSON.
+2. Decoded at config load time into `cfg.GCPServiceAccountKey`.
+3. `google.CredentialsFromJSONWithTypeAndParams()` creates credentials with scope `https://www.googleapis.com/auth/cloud-platform`.
+4. The raw key bytes are zeroed immediately after credential creation: `clear(cfg.GCPServiceAccountKey)` then `cfg.GCPServiceAccountKey = nil`.
+5. The `oauth2.TokenSource` is passed to the LLM provider factory and used per-request via `tokenSource.Token()`.
+
+## LLM Provider Conventions
+
+Both providers (`claude.go`, `gemini.go`) follow the same structure:
+- Accept `*config.Config` and `oauth2.TokenSource` at construction.
+- Build HTTP requests manually (no SDK). Use `httputil.NewHTTPClient()` with timeout from `cfg.ModelTimeoutSeconds` and SSL skip from `cfg.ModelSkipSSLVerify`.
+- Set `Authorization: Bearer <token>` header using `tokenSource.Token().AccessToken`.
+- Temperature is hardcoded to `0` for deterministic output.
+- Check non-200 responses for context window errors via `llmerrors.IsContextWindowError()` before returning generic errors.
+
+Provider-specific differences:
+- **Claude**: Endpoint pattern is `{ModelAPI}/anthropic/models/{ModelID}:streamRawPredict`. System prompt is a separate field.
+- **Gemini**: Endpoint pattern is `{ModelAPI}/v1beta/openai/chat/completions` (OpenAI-compatible). System prompt is prepended to the user message.
+
+## HTTP Client
+
+All HTTP clients are created through `internal/http/httpclient.go`. Rules:
+- Never create `http.Client{}` directly. Always use `httputil.NewHTTPClient(opts)`.
+- Only set `SkipSSLVerify: true` when the target is a self-hosted GitLab or when `cfg.ModelSkipSSLVerify` is set. Never skip SSL for GitHub.
+- Custom transport is only configured when SSL skip is needed. Otherwise, use the default transport.
+
+## External URL Fetching
+
+`internal/git/shared/external_url_fetcher.go` fetches documentation from external URLs:
+- Timeout: 30 seconds (hardcoded, separate from model timeout).
+- GitLab URLs get `PRIVATE-TOKEN` header and respect `GitLabSkipSSLVerify`.
+- GitLab detection: hostname is `gitlab.com`, `www.gitlab.com`, or starts with `gitlab.`.
+- Blob-to-raw URL conversion: replaces `/blob/` with `/raw/` in the path.
+
+## App-Interface Mode (CI/CD Pipeline)
+
+`internal/app_interface/app_interface.go` handles the CI/CD integration:
+- Project ID is hardcoded: `"service/app-interface"`.
+- Diff URLs come from a comment posted by `devtools-bot` that starts with `"Diffs:"`. URLs are extracted from lines starting with `"- "`.
+- User guidance from app-interface MR notes is always marked `IsAuthorized: true` (no authorization check).
+- Report posting: `client.Notes.CreateMergeRequestNote()` with the full report as the note body.
+
+## Shared Logic Location
+
+| Logic | Location | Why shared |
+|---|---|---|
+| QE label extraction | `shared/qe_labels.go` | Same label names on both platforms |
+| User guidance parsing (`/rcs` prefix) | `shared/user_guidance_parser.go` | Same format on both platforms |
+| Documentation fetching | `shared/documentation_fetcher.go` | Same `.release-confidence-docs.md` entry point |
+| External URL fetching | `shared/external_url_fetcher.go` | GitLab auth/SSL logic needed by both platforms |

--- a/docs/integration-guidelines.md
+++ b/docs/integration-guidelines.md
@@ -79,7 +79,9 @@ All HTTP clients are created through `internal/http/httpclient.go`. Rules:
 - Timeout: 30 seconds (hardcoded, separate from model timeout).
 - GitLab URLs get `PRIVATE-TOKEN` header and respect `GitLabSkipSSLVerify`.
 - GitLab detection: hostname is `gitlab.com`, `www.gitlab.com`, or starts with `gitlab.`.
-- Blob-to-raw URL conversion: replaces `/blob/` with `/raw/` in the path.
+
+Blob-to-raw URL conversion (`shared/documentation_fetcher.go`):
+- `fetchAdditionalDocContent` converts blob URLs to raw URLs via `strings.Replace(path, "/blob/", "/raw/", 1)` before passing them to `fetchExternalURL` -- works for both GitHub and GitLab URL formats.
 
 ## App-Interface Mode (CI/CD Pipeline)
 

--- a/docs/performance-guidelines.md
+++ b/docs/performance-guidelines.md
@@ -1,0 +1,147 @@
+# Performance Guidelines
+
+Conventions and patterns for concurrency, resource management, and API efficiency in this codebase.
+
+## 1. Parallel Fetching with errgroup
+
+All independent I/O operations run in parallel using `golang.org/x/sync/errgroup`. This is the only concurrency primitive used for parallelism in this codebase.
+
+**Rules:**
+
+- Create an errgroup from the incoming `context.Context` so cancellation propagates: `g, gCtx := errgroup.WithContext(ctx)`.
+- Use `gCtx` inside goroutines, never the parent `ctx` -- the errgroup context cancels sibling goroutines on first error.
+- After `g.Wait()` returns, `gCtx` is canceled. Any sequential work that follows must use the original `ctx`, not `gCtx`. See `user_guidance.go` where comments are processed sequentially after `g.Wait()` using the parent context.
+- Collect results into pre-declared variables scoped outside the goroutines, protected by a `sync.Mutex` when multiple goroutines append to the same slice.
+
+**Two-tier parallelism pattern:**
+
+The codebase uses two levels of parallel fetching:
+
+1. **Top level** (`release_analyzer.go`): Multiple compare URLs are fetched in parallel with no concurrency limit -- one goroutine per URL.
+2. **Per-URL level** (`FetchReleaseData`): Within each URL, diff+guidance and documentation run as two parallel errgroup goroutines. Diff and guidance are sequential within their goroutine because guidance depends on diff results.
+
+Do not add a third tier of nesting. Keep the fan-out flat.
+
+## 2. Concurrency Limits on API-Heavy Loops
+
+When iterating over a collection and making one API call per item (e.g., enriching each commit with PR/MR metadata), use `g.SetLimit(10)` to cap concurrent API calls.
+
+```go
+g, gCtx := errgroup.WithContext(ctx)
+g.SetLimit(10)
+
+for i, commit := range allCommits {
+    g.Go(func() error {
+        comparison.Commits[i] = buildCommitEntry(gCtx, client, commit, owner, repo, cache)
+        return nil
+    })
+}
+g.Wait()
+```
+
+**Rules:**
+
+- The limit of 10 is the standard in this codebase. Do not change it without measuring rate limit impact.
+- Write directly to a pre-allocated slice by index (`Commits[i]`) to avoid needing a mutex. This is safe because each goroutine writes to a distinct index.
+- These bounded goroutines always return `nil` -- errors are handled inside `buildCommitEntry` by logging and returning a partial result. This prevents one failed commit from aborting the entire enrichment.
+
+## 3. Thread-Safe Caching with sync.RWMutex
+
+PR and MR objects are cached per-execution to avoid redundant API calls (multiple commits often map to the same PR/MR). Both `prCache` (GitHub) and `mrCache` (GitLab) follow the identical pattern:
+
+**Rules:**
+
+- Use `sync.RWMutex` with read-lock for cache lookups and write-lock for cache inserts. Do not use a plain `sync.Mutex`.
+- The `getOrFetchPR`/`getOrFetchMR` methods use the check-release-fetch-store pattern: check cache under `RLock`, release lock, fetch if missing, store under `Lock`. These cache methods use manual `Lock()`/`Unlock()` without `defer` for the short critical sections.
+- Cache instances are scoped to a single compare URL execution and passed through the call chain via a `cache` parameter. They are not global.
+- When adding a new cache type (e.g., for a new API object), replicate the `prCache`/`mrCache` struct and `getOrFetchPR`/`getOrFetchMR` method pattern exactly. Keep GitHub and GitLab implementations symmetric.
+
+## 4. Mutex for Shared Slice Appends
+
+When multiple errgroup goroutines append to shared result slices, protect appends with a single `sync.Mutex`:
+
+```go
+var mu sync.Mutex
+var comparisons []*types.Comparison
+
+for _, url := range uniqueURLs {
+    g.Go(func() error {
+        // ... fetch comparison ...
+        mu.Lock()
+        defer mu.Unlock()
+        comparisons = append(comparisons, comparison)
+        return nil
+    })
+}
+```
+
+**Rules:**
+
+- Use one mutex for all shared slices in the same scope (not one mutex per slice).
+- Hold the lock only for the append operations, not for the fetch.
+- When order matters, use indexed writes to a pre-allocated slice instead (see commit enrichment pattern above).
+
+## 5. HTTP Client Timeouts
+
+HTTP clients are created per-request or per-operation via `httputil.NewHTTPClient()`. There are no shared/global HTTP clients.
+
+**Rules:**
+
+- External URL fetches (documentation): 30-second timeout, hardcoded as `const httpTimeout = 30 * time.Second`.
+- LLM API calls: configurable via `RCS_MODEL_TIMEOUT_SECONDS` (default 120 seconds). Applied as `time.Duration(cfg.ModelTimeoutSeconds) * time.Second`.
+- Git platform SDK clients (GitHub, GitLab): no explicit timeout set on the HTTP client. Timeouts rely on context cancellation from errgroup.
+- Always pass `context.Context` to requests (`http.NewRequestWithContext`, `gitlab.WithContext(ctx)`) so that errgroup cancellation terminates in-flight requests.
+
+## 6. Context Propagation
+
+Every function that makes an API call or I/O operation accepts `context.Context` as its first parameter.
+
+**Rules:**
+
+- `FetchReleaseData`, `fetchDiff`, `fetchUserGuidance`, `buildCommitEntry`, `getOrFetchPR/MR`, and all documentation methods take `ctx`.
+- GitLab SDK calls require explicit context passing via `gitlab.WithContext(ctx)`. GitHub SDK methods accept `ctx` as a regular parameter.
+- The top-level `getReleaseData` creates its context from `context.Background()` -- there is no request-scoped context above this. Do not change this without adding a timeout or signal handler at the `main` level.
+
+## 7. Pagination
+
+Both GitHub and GitLab APIs require pagination for large result sets.
+
+**Rules:**
+
+- Always use `PerPage: 100` (the maximum) to minimize API round-trips.
+- Paginate with a `for` loop checking `resp.NextPage == 0` as the termination condition.
+- GitHub comparison API requires special pagination: store the comparison metadata from page 1 only, accumulate commits from all pages.
+- Use the generic `fetchAllPaginated[T]` helper (GitHub only) for paginated list endpoints. GitLab pagination is done inline since the SDK API differs.
+
+## 8. Deduplication Before Parallel Work
+
+Deduplicate inputs before spawning goroutines to avoid redundant API calls:
+
+- Compare URLs are deduplicated in `getReleaseData` before parallel fetching.
+- PR/MR numbers are tracked with `processedPRs`/`processedMRs` maps in user guidance extraction to avoid processing the same PR/MR twice.
+
+## 9. Progressive Truncation for LLM Retries
+
+When the LLM rejects input due to context window limits, the system retries with progressively more aggressive truncation levels: `low -> moderate -> high -> extreme`.
+
+**Rules:**
+
+- Only retry on `ContextWindowError` (detected by status code 400/413/429 and body keyword matching). All other errors fail immediately.
+- Each retry level is a full re-format and re-send -- there is no caching of intermediate formatted prompts.
+- Truncation is risk-aware: critical files (auth, DB, API schemas) are never truncated. Low-risk files (docs, tests) are truncated first.
+- Documentation linked from the entry point doc is stripped entirely at `high` and `extreme` levels.
+
+## 10. Credential Cleanup
+
+Sensitive credentials are zeroed after use:
+
+```go
+clear(cfg.GCPServiceAccountKey)
+cfg.GCPServiceAccountKey = nil
+```
+
+This happens immediately after `google.CredentialsFromJSONWithTypeAndParams` returns, whether it succeeds or fails.
+
+## 11. Regex Compilation
+
+All regular expressions are compiled at package level (`var fooRegex = regexp.MustCompile(...)`) rather than inside functions. This includes URL matching patterns, documentation section parsing, and bot comment extraction. Never compile a regex inside a loop or a frequently-called function.

--- a/docs/security-guidelines.md
+++ b/docs/security-guidelines.md
@@ -1,0 +1,131 @@
+# Security Guidelines
+
+## 1. Authentication Architecture
+
+### GCP OAuth2 for LLM APIs (Primary Auth)
+Both LLM providers (Claude, Gemini) authenticate via GCP OAuth2 service account tokens -- not static API keys.
+
+**Rules:**
+- All LLM clients receive an `oauth2.TokenSource`, not raw credentials. Tokens are obtained per-request via `tokenSource.Token()`.
+- The `Authorization: Bearer` header is set from the `TokenSource` on every request; never cache or store the access token string outside the OAuth2 library.
+- When obtaining credentials fails, wipe the key material before returning the error (see credential clearing below).
+
+### Git Platform Tokens (PATs)
+GitHub and GitLab use static personal access tokens passed via environment variables.
+
+**Rules:**
+- GitHub: Token is passed to `github.NewClient(nil).WithAuthToken(token)`. Never construct auth headers manually for the GitHub SDK.
+- GitLab: Token is passed to `gitlab.NewClient(token, ...)`. For raw HTTP requests to GitLab URLs, use the `PRIVATE-TOKEN` header (not `Authorization: Bearer`).
+
+```go
+// Correct: GitLab raw HTTP auth
+req.Header.Set("PRIVATE-TOKEN", d.config.GitLabToken)
+```
+
+## 2. Credential Lifecycle: Clear After Use
+
+The GCP service account key (`GCPServiceAccountKey` in `Config`) is a `[]byte` that must be wiped from memory after credential initialization succeeds or fails.
+
+**Rules:**
+- After calling `google.CredentialsFromJSONWithTypeAndParams`, immediately call `clear(cfg.GCPServiceAccountKey)` and set it to `nil`, regardless of success or failure.
+- This pattern lives in `internal/release_analyzer.go` `New()`. Any new code path that reads `GCPServiceAccountKey` must follow the same wipe pattern.
+- The `Config` struct comment documents this: `GCPServiceAccountKey []byte // cleared after credential initialization`.
+
+```go
+creds, err := google.CredentialsFromJSONWithTypeAndParams(context.Background(), cfg.GCPServiceAccountKey, ...)
+if err != nil {
+    clear(cfg.GCPServiceAccountKey)
+    cfg.GCPServiceAccountKey = nil
+    return nil, fmt.Errorf("failed to parse GCP service account credentials")
+}
+clear(cfg.GCPServiceAccountKey)
+cfg.GCPServiceAccountKey = nil
+```
+
+## 3. Secret Storage and .gitignore
+
+**Rules:**
+- `.env` is gitignored; `.env.example` is committed with placeholder values only (e.g., `your_github_token_here`).
+- The binary (`/rcs`) and `.claude/` directory are also gitignored.
+- Never commit real tokens. Test files use obvious fake values like `"github-token"`, `"gitlab-token"`, `"dGVzdA=="` (base64 of "test").
+- `RCS_GOOGLE_SA_KEY_B64` is base64-encoded in the environment to handle JSON special characters. Decode with `base64.StdEncoding.DecodeString` and `strings.TrimSpace` the input first.
+
+## 4. Error Messages: Never Leak Credentials
+
+**Rules:**
+- When credential parsing fails, return a generic message without echoing the input. Example: `"RCS_GOOGLE_SA_KEY_B64 contains invalid base64 encoding"` -- not `"failed to decode: <raw value>"`.
+- When OAuth2 token acquisition fails, return `"failed to obtain authentication token"` without wrapping the underlying error (which may contain token details).
+- For API errors, it is acceptable to include the HTTP status code and response body, since these come from the server, not from local secrets.
+
+## 5. TLS Configuration
+
+**Rules:**
+- TLS verification is enabled by default. SSL skip is opt-in via boolean env vars (`RCS_GITLAB_SKIP_SSL_VERIFY`, `RCS_MODEL_SKIP_SSL_VERIFY`), both defaulting to `false`.
+- SSL skip is scoped per-subsystem: GitLab client and LLM model client have independent skip flags. Never apply a global skip.
+- The `SkipSSLVerify` flag in `HTTPClientOptions` only creates a custom `Transport` when `true`; otherwise the default Go TLS behavior applies.
+- For external URL fetching (documentation links), SSL skip is applied only when the URL is detected as a GitLab URL AND `GitLabSkipSSLVerify` is `true`. Non-GitLab external URLs always verify TLS.
+
+```go
+skipSSLVerify := isGitLab && d.config.GitLabSkipSSLVerify
+```
+
+## 6. HTTP Client Configuration
+
+**Rules:**
+- Always set a timeout on HTTP clients. LLM clients use `ModelTimeoutSeconds` (default 120s). External URL fetching uses a 30-second constant (`httpTimeout`).
+- Use the shared `httputil.NewHTTPClient()` factory -- never construct `http.Client{}` directly. This ensures consistent TLS and timeout configuration.
+- Limit concurrent API calls with `errgroup.SetLimit(10)` to avoid rate-limiting from GitHub/GitLab APIs.
+
+## 7. Input Validation
+
+### Environment Variables
+- All env vars are validated at startup in `config.Load()` before any network calls.
+- Integer env vars are range-checked (`parseIntEnvOrDefault` enforces `min`/`max`).
+- Boolean env vars use `strconv.ParseBool` (accepts `true/false/1/0` only; rejects `yes/no`).
+- Log format and level are validated against allowlists.
+- If `GitLabToken` is set, `GitLabBaseURL` is required. If mode is `app-interface`, `GitLabToken` is required.
+
+### URL Parsing
+- Compare URLs are validated by regex before processing: `githubCompareRegex` and `gitlabCompareRegex`. Invalid URLs are rejected with an explicit error.
+- GitLab project paths are URL-encoded with `url.PathEscape` before use in API calls.
+- GitLab URL detection for SSL config uses `url.Parse` with a fallback to string matching if parsing fails.
+
+## 8. User Guidance Authorization
+
+User guidance (comments that influence the LLM analysis) is filtered by authorization status before being included in the prompt.
+
+**Rules:**
+- Only authorized guidance reaches the LLM. The function `extractAuthorizedGuidance` filters on `IsAuthorized == true`.
+- GitHub authorization: user must be the PR author OR have an `APPROVED` review with `AuthorAssociation` of `OWNER`, `MEMBER`, or `COLLABORATOR`. Random commenters cannot influence scoring.
+- GitLab authorization: user must be the MR author OR be in the MR's approvers list. GitLab's approval system is permission-based, so approver presence is sufficient.
+- App-interface (GitLab) guidance is always marked `IsAuthorized: true` because it comes from a controlled internal MR.
+
+## 9. Container Security
+
+**Rules:**
+- Multi-stage Docker build: build stage uses `ubi9/go-toolset`, runtime uses `ubi9/ubi-minimal`. Build tools are not present in the final image.
+- Runtime container runs as non-root user (`USER 1001`).
+- Binary is built with `CGO_ENABLED=0` (static linking, no C dependencies in the image).
+- Tekton pipelines use `hermetic: 'true'` for reproducible, network-isolated builds.
+- Git auth in Tekton uses a Kubernetes secret reference (`git_auth_secret`), not inline credentials.
+
+## 10. CI/CD Security
+
+**Rules:**
+- GitHub Actions workflow sets `permissions: contents: read` (principle of least privilege).
+- GitHub Actions are pinned to full commit SHAs, not tags, to prevent supply chain attacks via tag mutation.
+- Tekton pipeline references use versioned URLs (e.g., `v1.67.1`), not `latest` or `main`.
+- Tekton service accounts are scoped per-component (`build-pipeline-rcs-app-interface`).
+
+## 11. Logging Discipline
+
+**Rules:**
+- Credentials and tokens are never logged. The `slog.Debug` calls in LLM clients log request/response payloads (which contain prompts and analysis, not auth headers) but the `Authorization` header is set after the debug log.
+- Rate limit remaining counts are logged at debug level (safe metadata).
+- Debug logging is off by default (log level defaults to `info`). Enable with `RCS_LOG_LEVEL=debug` only in non-production.
+
+## 12. Security-Sensitive File Detection (LLM Prompt)
+
+The system prompt instructs the LLM to flag security concerns in analyzed diffs. When modifying system prompts:
+- Maintain the "Security & Sensitive Data" checklist: hardcoded secrets, logging in auth/PII paths, error message leakage, input validation changes, dependency CVEs.
+- File criticality tiers must classify `auth/`, security changes, and authentication as "Critical".

--- a/docs/testing-guidelines.md
+++ b/docs/testing-guidelines.md
@@ -1,0 +1,168 @@
+# Testing Guidelines
+
+## File Organization
+
+- Test files live alongside source files in the same package (e.g., `diff.go` and `diff_test.go`).
+- Tests use the same package name as the source (no `_test` suffix on the package declaration), giving access to unexported functions.
+- No separate `testdata/` directories, fixtures, or golden files exist in this repo. All test data is constructed inline.
+
+## Table-Driven Tests
+
+Table-driven tests are the dominant pattern. Follow this structure exactly:
+
+- Name the slice `tests` (not `testCases`, `cases`, etc.).
+- Use the loop variable `tt` (not `tc` or `test`).
+- Every test case must have a `name string` field as the first field.
+- Call `t.Run(tt.name, ...)` for every case.
+
+```go
+tests := []struct {
+    name     string
+    input    string
+    expected string
+}{
+    {"descriptive name", "input", "expected"},
+}
+
+for _, tt := range tests {
+    t.Run(tt.name, func(t *testing.T) {
+        // ...
+    })
+}
+```
+
+When a function returns multiple values, use separate `expected`/`want` fields per output (e.g., `wantOwner`, `wantRepo`, `wantErr`). Do not pack multiple outputs into a single struct.
+
+## Subtests Without Tables
+
+For tests that need unique setup per case or test stateful/multi-step behavior, use named subtests directly:
+
+```go
+t.Run("single page", func(t *testing.T) { ... })
+t.Run("multiple pages", func(t *testing.T) { ... })
+```
+
+This pattern is used for pagination tests, combined metadata tests, and truncation scenarios.
+
+## Assertion Style
+
+- Use `t.Errorf` for non-fatal failures and `t.Fatalf` only when subsequent assertions depend on the failed value.
+- Use `t.Fatal` / `t.Fatalf` for nil checks that would cause panics downstream.
+- No assertion libraries (testify, etc.) are used. Stick to standard `testing` package.
+- Format error messages as: `t.Errorf("FunctionName() = %v, want %v", got, want)` or `t.Errorf("field = %q, want %q", got, want)`. Use `%q` for strings, `%v` or `%d` for other types.
+- For error cases, check `err == nil` then return early. For expected errors containing a substring, use `strings.Contains(err.Error(), "substring")`.
+
+## Parallel Tests
+
+`t.Parallel()` is **not used** anywhere in this codebase. Do not add it.
+
+## Mocking External Services
+
+### httptest for HTTP APIs
+
+LLM provider tests and external URL fetch tests use `httptest.NewServer` to mock HTTP endpoints. Always `defer server.Close()`. Pass `server.URL` as the API endpoint via config:
+
+```go
+server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+    // Verify request properties
+    // Write response
+}))
+defer server.Close()
+
+cfg := &config.Config{ModelAPI: server.URL, ...}
+```
+
+Provider tests verify request method, Content-Type, and Authorization headers inside the handler.
+
+### Interface Mocks
+
+Mocks are hand-written structs in test files (no code generation or mocking libraries). They are defined in the test file that uses them, not in shared test helpers.
+
+Three mock patterns exist:
+
+1. **`mockDocumentationSource`** (in `documentation_fetcher_test.go`): Uses maps for file content and errors. Implements `types.DocumentationSource`.
+
+2. **`mockGitProvider`** (in `release_analyzer_test.go`): Uses function fields for flexible behavior per test. Tracks call count.
+
+3. **`mockLLMClient`** (in `release_analyzer_test.go`): Uses response/error slices indexed by call count to simulate multi-call sequences (e.g., retry scenarios).
+
+When a mock needs dynamic behavior per test case, use function fields:
+```go
+type mockGitProvider struct {
+    isCompareURL func(url string) bool
+    fetchResult  *types.Comparison
+    fetchErr     error
+}
+```
+
+### OAuth2 Token Mocks
+
+LLM provider tests mock `oauth2.TokenSource` with a `staticTokenSource` for success and an `errorTokenSource` for authentication failures. These are defined once in `claude_test.go` and reused by `gemini_test.go` and `factory_test.go` within the same package.
+
+## Environment Variables in Tests
+
+Use `t.Setenv()` for environment variables. This automatically cleans up after the test. Never use raw `os.Setenv` in new tests.
+
+For CLI tests that modify `os.Args`, save and restore manually:
+```go
+oldArgs := os.Args
+defer func() { os.Args = oldArgs }()
+os.Args = tt.args
+```
+
+## Testing for Contains vs Equality
+
+- Use exact equality (`!=`, `==`) when testing a single deterministic output.
+- Use `strings.Contains` when testing that rendered/formatted output includes expected fragments. This is the standard pattern for template rendering and report generation tests.
+- When checking multiple fragments in output, use `expectInOutput` / `expectNotInOutput` string slices in the table struct.
+
+## Nil and Edge Case Coverage
+
+Every function that accepts pointers or slices must be tested with nil inputs. The established patterns:
+- Nil pointer input (e.g., `nil PR`, `nil MR`, `nil comparison`)
+- Empty slice/map input
+- Slice containing nil elements (e.g., `[]*types.Comparison{nil}`)
+- Zero-value structs
+
+## GitHub/GitLab Test Parity
+
+When tests exist for `git/github/`, equivalent tests should exist for `git/gitlab/` testing the same logical behaviors. The test case names and structure should mirror each other.
+
+## Skipping Tests That Need Complex Mocks
+
+When a test would require mocking a full SDK client and that mock does not yet exist, use `t.Skip` with a clear reason:
+
+```go
+t.Skip("Skipping - requires mock GitLab client to test deduplication logic")
+```
+
+Do not write empty or misleading tests. Either test it properly or skip with rationale.
+
+## Test Helper Functions
+
+- Helper functions are defined in the test file that uses them (e.g., `validLLMResponse()` in `release_analyzer_test.go`).
+- No shared test utility packages exist. If a mock is needed across files in the same package, it can be defined once and reused (like `mockTS()` in the providers package).
+- Factory helpers like `newTestAnalyzer()` encapsulate construction of the system under test with mock dependencies.
+
+## What Is Tested
+
+- **Pure functions**: Converters, parsers, formatters, validators (most tests)
+- **HTTP client interactions**: LLM providers via httptest (Claude, Gemini)
+- **Configuration loading**: Environment variable parsing and validation
+- **CLI argument parsing**: Flag parsing and validation
+- **Template rendering**: Report generation with various input combinations
+- **Retry/truncation logic**: Context window error handling with multi-call mock sequences
+
+## What Is Not Tested
+
+- Direct GitHub/GitLab SDK calls (tests cover the wrapper logic, not API calls)
+- `main.go` and the top-level wiring
+- Actual LLM responses or end-to-end flows
+
+## Running Tests
+
+```bash
+go test ./...
+```
+
+No build tags, test flags, or special setup required.


### PR DESCRIPTION
Create a layered documentation system for AI-assisted development:
- 6 domain-specific guideline files in `docs/` (security, performance, error-handling, api-contracts, testing, integration), each explored from the codebase, generated, and verified by independent agents
- `AGENTS.md` with cross-cutting conventions, architecture overview, guideline index, and path-to-guideline mapping
- Slim `CLAUDE.md` importing `@AGENTS.md` with Claude Code-exclusive build commands and environment requirements
- 7 path-scoped rule files in `.claude/rules/` that auto-load relevant guidelines when Claude works in specific directories
- Updated `.gitignore` to track `.claude/rules/` while ignoring other `.claude/` contents