### PR TITLE
Add continuous doc improvement loop

### DIFF
--- a/.claude/scripts/capture-friction.sh
+++ b/.claude/scripts/capture-friction.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# Friction capture script — runs as a Claude Code Stop hook.
+# Analyzes the session transcript for friction events and writes
+# one markdown file per event to .claude/friction/.
+
+LOG_FILE="${CLAUDE_PROJECT_DIR:-.}/.claude/friction/capture.log"
+
+log() {
+  echo "$(date +%H:%M:%S) $1" >> "$LOG_FILE"
+}
+
+# Opt-in: set FRICTION_CAPTURE=1 in .claude/settings.local.json
+if [ "$FRICTION_CAPTURE" != "1" ]; then
+  exit 0
+fi
+
+# Stop hook receives JSON on stdin with transcript_path and session_id
+INPUT=$(cat)
+
+# Prevent infinite recursion if this hook triggers another Stop
+if echo "$INPUT" | jq -e '.stop_hook_active == true' > /dev/null 2>&1; then
+  exit 0
+fi
+
+TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path')
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id')
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
+FRICTION_DIR="$PROJECT_DIR/.claude/friction"
+TODAY=$(date +%Y-%m-%d)
+SHORT_SESSION=$(echo "$SESSION_ID" | cut -c1-4)
+
+# Extract human/assistant messages from the JSONL transcript, truncate each to 2000 chars
+TRANSCRIPT=$(jq -r '
+  select(.role == "user" or .role == "assistant") |
+  "[" + .role + "]: " + (
+    if (.content | type) == "array"
+    then [.content[] | select(.type == "text") | .text] | join(" ")
+    else (.content // "")
+    end
+  )[:2000]
+' "$TRANSCRIPT_PATH")
+
+mkdir -p "$(dirname "$LOG_FILE")"
+
+# Skip near-empty sessions
+if [ ${#TRANSCRIPT} -lt 200 ]; then
+  log "Session $SHORT_SESSION: transcript too short, skipping"
+  exit 0
+fi
+
+# Ask Haiku to identify friction events as a JSON array
+PROMPT="Analyze this coding agent session for friction signals.
+
+Friction = moments where the human corrected the agent, the agent asked a question
+it shouldn't have needed to ask, the agent made a wrong assumption, or a tool call
+was denied.
+
+For each friction event found, output a JSON array. Each element must have these fields:
+- type: one of correction, clarification, denial, mistake
+- severity: one of low, medium, high
+- slug: short-kebab-case-description
+- doc_gap: path/to/guideline.md or none
+- description: one paragraph describing what went wrong and what the correct behavior should have been
+
+If no friction was found, output an empty array: []
+
+Output ONLY the JSON array, no other text.
+
+TRANSCRIPT:
+$TRANSCRIPT"
+
+log "Session $SHORT_SESSION: analyzing transcript for friction..."
+
+# Uses the claude CLI so the hook inherits the contributor's existing auth
+RESULT=$(echo "$PROMPT" | claude -p --model haiku)
+
+if [ -z "$RESULT" ] || [ "$RESULT" = "[]" ]; then
+  log "Session $SHORT_SESSION: no friction found"
+  exit 0
+fi
+
+if ! echo "$RESULT" | jq empty 2>/dev/null; then
+  log "Session $SHORT_SESSION: Haiku returned invalid JSON, skipping"
+  exit 0
+fi
+
+EVENT_COUNT=$(echo "$RESULT" | jq 'length')
+log "Session $SHORT_SESSION: found $EVENT_COUNT friction event(s)"
+
+mkdir -p "$FRICTION_DIR"
+
+# Write one markdown file per friction event
+echo "$RESULT" | jq -c '.[]' | while read -r event; do
+  SLUG=$(echo "$event" | jq -r '.slug // "unknown"')
+  TYPE=$(echo "$event" | jq -r '.type')
+  SEVERITY=$(echo "$event" | jq -r '.severity')
+  DOC_GAP=$(echo "$event" | jq -r '.doc_gap')
+  DESC=$(echo "$event" | jq -r '.description')
+
+  FILENAME="${TODAY}-${SHORT_SESSION}-${SLUG}.md"
+  log "  -> $FILENAME ($TYPE, $SEVERITY)"
+  cat > "$FRICTION_DIR/$FILENAME" <<EOF
+---
+type: $TYPE
+severity: $SEVERITY
+slug: $SLUG
+doc_gap: $DOC_GAP
+session: $SHORT_SESSION
+date: $TODAY
+---
+
+$DESC
+EOF
+done
+
+log "Session $SHORT_SESSION: friction capture complete"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/scripts/capture-friction.sh",
+            "timeout": 30000
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/improve-docs/SKILL.md
+++ b/.claude/skills/improve-docs/SKILL.md
@@ -1,0 +1,64 @@
+# Improve Documentation from Friction
+
+Process captured friction events and propose documentation and eval improvements.
+
+## Instructions
+
+1. Read all markdown files from `.claude/friction/` directory. If no friction files exist, report "No friction files to process" and stop.
+
+2. For each friction file, extract the YAML frontmatter (`type`, `severity`, `slug`, `doc_gap`, `session`, `date`) and the body description.
+
+3. Analyze the friction events as a batch:
+   - Group by `doc_gap` field to identify which guideline docs need updates.
+   - Filter out noise: single low-severity events with no clear doc gap are likely random sampling errors or one-off edge cases. Flag them for the user but do not propose changes.
+   - Identify patterns: multiple events pointing to the same guideline doc are high-confidence signals.
+
+4. For each identified doc gap:
+   - Read the existing guideline file (e.g., `docs/security-guidelines.md`).
+   - Propose a specific edit: add a rule, add an example, clarify an existing rule.
+   - The edit should prevent the friction from recurring.
+   - Follow existing doc formatting conventions (numbered sections with `##` headers, code examples).
+   - Keep additions concise — one rule per friction event, not a paragraph.
+   - Do not reorganize existing content. Add to the relevant section.
+   - Each guideline file must not exceed 200 lines after editing. If an edit would push a file over 200 lines, consolidate or tighten existing rules instead of appending.
+
+5. For friction events where `doc_gap` is "none":
+   - Determine if the friction points to a missing guideline topic.
+   - If so, propose adding content to the most relevant existing guideline file, or suggest a new path-scoped rule in `.claude/rules/`.
+
+6. Optionally propose new eval cases:
+   - For friction events that are grader-friendly (the expected behavior can be verified with `contains`/`not-contains` or `llm-rubric` assertions), propose a new test case in `promptfoo.yaml`.
+   - Each test case needs: `description`, `vars.task`, and at least one `assert`.
+   - The task description should be a realistic coding request that would trigger the friction pattern.
+   - Prefer `contains`/`not-contains` for concrete patterns, `llm-rubric` for nuanced intent.
+
+7. Delete all processed friction files from `.claude/friction/`.
+
+8. Create a new git branch named `friction/improve-docs-YYYY-MM-DD` (add a short suffix if the branch already exists).
+
+9. Stage and commit all changes (doc edits, eval additions).
+   Use commit message format: `docs: improve guidelines from friction capture`
+
+10. Push the branch and open a PR using `gh pr create`:
+    - Title: `docs: improve guidelines from friction capture`
+    - Body: summary of what was changed and why, listing each friction event that drove each change. End with the standard `Generated with Claude Code` footer.
+    - Base branch: `main`
+
+11. After the PR is created, post a metrics comment on the PR using `gh pr comment` with this format:
+
+    ```
+    ## Friction Metrics
+
+    | Metric | Count |
+    |---|---|
+    | Total friction events | N |
+    | Corrections | N |
+    | Clarifications | N |
+    | Denials | N |
+    | Mistakes | N |
+    | Docs improved | N |
+    | Eval cases added | N |
+    | Noise (discarded) | N |
+
+    **Docs improved:** `file1.md`, `file2.md`
+    ```

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Reminds contributors to process friction files before they pile up.
+
+FRICTION_DIR=".claude/friction"
+COUNT=$(find "$FRICTION_DIR" -name "*.md" 2>/dev/null | wc -l)
+
+if [ "$COUNT" -ge 5 ]; then
+  echo "Warning: $COUNT friction files are waiting in .claude/friction/ — the docs will thank you for running /improve-docs soon!"
+elif [ "$COUNT" -gt 0 ]; then
+  echo "Note: $COUNT friction file(s) captured in .claude/friction/. Run /improve-docs whenever you're ready."
+fi

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -1,0 +1,26 @@
+name: AI Evals
+
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - '.claude/**'
+      - 'CLAUDE.md'
+      - 'AGENTS.md'
+      - 'promptfoo.yaml'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  eval:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: promptfoo/promptfoo-action@cad6100f9d4d35f0a1d7aa036d2d8a8d223b483b # v1
+        with:
+          config: promptfoo.yaml
+          cache-path: ~/.cache/promptfoo
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
-/.claude/
+/.claude/*
 !/.claude/rules/
-!/.claude/rules/**
+!/.claude/settings.json
+!/.claude/scripts/
+!/.claude/skills/
 /.idea/
 /.env
+/.promptfoo/
 /rcs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,3 +136,23 @@ The codebase has minimal direct dependencies (see `go.mod`):
 
 No web frameworks, no assertion libraries, no code generation tools, no mocking libraries.
 
+### Friction Capture and Continuous Improvement
+
+This repo has an automatic friction capture system. At the end of every Claude Code session, a Stop hook analyzes the conversation transcript and writes friction events (corrections, clarifications, denials, mistakes) as individual markdown files to `.claude/friction/`.
+
+#### For contributors
+
+1. Run `git config core.hooksPath .githooks` once after cloning.
+2. Work normally. Friction is captured automatically.
+3. Before pushing, if friction files exist, run `/improve-docs`.
+4. The command proposes doc and eval improvements, opens a PR, and deletes the friction files.
+5. Push goes through. Team reviews the PR normally.
+
+#### Friction file format
+
+Each file in `.claude/friction/` has YAML frontmatter with `type`, `severity`, `slug`, `doc_gap`, `session`, and `date` fields, followed by a one-paragraph description.
+
+#### Evals
+
+Run evals locally with `promptfoo eval` after doc changes. CI runs evals automatically on PRs that touch docs or agent context files (`.github/workflows/evals.yml`).
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,21 @@ docker compose run --rm rcs --compare-links "https://github.com/org/repo/compare
 
 ### Environment Requirements
 - Go 1.25.0 or later
-- No pre-commit hooks configured
 - No linter configuration (follow Go standard formatting)
 - No vendoring (dependencies via `go mod download`)
+
+## Setup (once per clone)
+
+```bash
+git config core.hooksPath .githooks
+```
+
+To enable friction capture, add to `.claude/settings.local.json`:
+
+```json
+{
+  "env": {
+    "FRICTION_CAPTURE": "1"
+  }
+}
+```

--- a/promptfoo.yaml
+++ b/promptfoo.yaml
@@ -1,0 +1,134 @@
+description: "RCS agent context evals"
+
+prompts:
+  - >
+    You are an AI coding agent working on the Release Confidence Score (RCS) project,
+    a Go application that analyzes release diffs from GitHub and GitLab and generates
+    confidence reports using LLM providers (Claude, Gemini) via GCP Vertex AI.
+
+    Follow the project guidelines below.
+
+    {% include "docs/security-guidelines.md" %}
+    {% include "docs/error-handling-guidelines.md" %}
+    {% include "docs/testing-guidelines.md" %}
+    {% include "docs/api-contracts-guidelines.md" %}
+    {% include "docs/performance-guidelines.md" %}
+    {% include "docs/integration-guidelines.md" %}
+
+providers:
+  - id: vertex:messages:claude-sonnet-4-6
+    config:
+      max_tokens: 4096
+
+tests:
+  # From security-guidelines.md: credential clearing
+  - description: "GCP service account key must be cleared after use"
+    vars:
+      task: >
+        Add a new LLM provider that uses GCP OAuth2 authentication.
+        Show how to initialize the credentials from the config's
+        GCPServiceAccountKey field.
+    assert:
+      - type: contains
+        value: "clear("
+      - type: llm-rubric
+        value: >
+          The code clears the GCP service account key bytes after
+          credential initialization using clear(), whether it succeeds
+          or fails. The key field is set to nil after clearing.
+
+  # From error-handling-guidelines.md: error wrapping
+  - description: "Errors use fmt.Errorf with %w and verb-first prefix"
+    vars:
+      task: >
+        Write error handling for a function that fetches repository
+        metadata from the GitHub SDK using the go-github client.
+    assert:
+      - type: contains
+        value: "fmt.Errorf"
+      - type: contains
+        value: "%w"
+      - type: not-contains
+        value: "log.Fatal"
+      - type: llm-rubric
+        value: >
+          Error messages use lowercase verb-first prefixes like
+          "failed to fetch" or "failed to get". Errors are returned
+          with fmt.Errorf and %w wrapping. Internal packages never
+          call log.Fatal or log.Fatalf.
+
+  # From testing-guidelines.md: table-driven tests
+  - description: "Tests use table-driven pattern with correct conventions"
+    vars:
+      task: >
+        Write a test for a function that parses GitHub compare URLs
+        and extracts the owner, repo, base ref, and head ref.
+    assert:
+      - type: contains
+        value: "tests := []struct"
+      - type: contains
+        value: "t.Run(tt.name"
+      - type: not-contains
+        value: "assert."
+      - type: llm-rubric
+        value: >
+          Uses table-driven test pattern with slice named "tests"
+          (not "testCases"), loop variable "tt", and t.Run for each
+          case. Uses standard testing package assertions (t.Errorf
+          or t.Fatalf), not testify or any assertion library.
+
+  # From api-contracts-guidelines.md: GitProvider interface
+  - description: "New git providers implement the GitProvider interface"
+    vars:
+      task: >
+        Add a new Bitbucket git provider that implements the
+        GitProvider interface for fetching release data from
+        Bitbucket compare URLs.
+    assert:
+      - type: contains
+        value: "IsCompareURL"
+      - type: contains
+        value: "FetchReleaseData"
+      - type: contains
+        value: "Name()"
+      - type: llm-rubric
+        value: >
+          The provider implements all three GitProvider methods:
+          IsCompareURL (URL detection via compiled regex),
+          FetchReleaseData (returns Comparison, UserGuidance,
+          and Documentation), and Name. FetchReleaseData returns
+          all data in one call, not separate methods.
+
+  # From performance-guidelines.md: errgroup with SetLimit
+  - description: "Concurrent API calls use errgroup with SetLimit(10)"
+    vars:
+      task: >
+        Write a function that enriches a list of commits with
+        pull request metadata by making one GitHub API call per
+        commit, running them concurrently.
+    assert:
+      - type: contains
+        value: "errgroup"
+      - type: contains
+        value: "SetLimit(10)"
+      - type: llm-rubric
+        value: >
+          Uses errgroup.WithContext for parallel API calls with
+          g.SetLimit(10) to cap concurrency. Uses gCtx (the
+          errgroup context) inside goroutines, not the parent ctx.
+
+  # From integration-guidelines.md: platform parity
+  - description: "GitHub changes must consider GitLab parity"
+    vars:
+      task: >
+        Add a new field 'releaseNotes' to the commit enrichment
+        in the GitHub provider's diff.go file that fetches release
+        notes associated with each commit's tag.
+    assert:
+      - type: llm-rubric
+        value: >
+          The response either implements the same change for the
+          GitLab provider or explicitly notes that the equivalent
+          change should be made in the GitLab package. Any new data
+          types are added to internal/git/types/ (platform-agnostic),
+          not as GitHub-specific fields.


### PR DESCRIPTION
- Stop hook captures friction events as markdown files via Haiku analysis
- /improve-docs skill processes friction into doc + eval PRs
- Pre-push git hook warns about unprocessed friction files
- promptfoo evals with 6 test cases (one per guideline doc)
- CI workflow runs evals on PRs touching docs or agent context
- Friction capture opt-in via FRICTION_CAPTURE env var in settings.local.json