### PR TITLE
Improve friction capture

### DIFF
--- a/.claude/scripts/capture-friction.sh
+++ b/.claude/scripts/capture-friction.sh
@@ -1,55 +1,102 @@
 #!/bin/bash
-# Friction capture script — runs as a Claude Code Stop hook.
-# Analyzes the session transcript for friction events and writes
-# one markdown file per event to .claude/friction/.
+# Friction capture script — runs as a Claude Code SessionEnd hook.
+#
+# At the end of every session, Claude Code invokes this script with a JSON payload
+# on stdin containing the transcript path. This script asks a small LLM (Haiku) to
+# scan the transcript for friction events (corrections, mistakes, clarifications,
+# denied tool calls) and writes one markdown file per event to .claude/friction/.
+#
+# Those files are later processed by /improve-docs to propose doc improvements.
+# Enable with FRICTION_CAPTURE=1 in .claude/settings.local.json.
 
-LOG_FILE="${CLAUDE_PROJECT_DIR:-.}/.claude/friction/capture.log"
+if [ "$FRICTION_CAPTURE" != "1" ]; then
+  exit 0
+fi
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
+FRICTION_DIR="$PROJECT_DIR/.claude/friction"
+LOG_FILE="$FRICTION_DIR/capture.log"
+
+mkdir -p "$FRICTION_DIR"
 
 log() {
   echo "$(date +%H:%M:%S) $1" >> "$LOG_FILE"
 }
 
-# Opt-in: set FRICTION_CAPTURE=1 in .claude/settings.local.json
-if [ "$FRICTION_CAPTURE" != "1" ]; then
-  exit 0
-fi
+LOCKFILE="$FRICTION_DIR/.capture.lock"
 
-# Stop hook receives JSON on stdin with transcript_path and session_id
+# Read the JSON payload from stdin synchronously. This must happen before we
+# background anything: Claude Code closes stdin when the hook process exits, so
+# a background subshell cannot read it.
 INPUT=$(cat)
 
-# Prevent infinite recursion if this hook triggers another Stop
-if echo "$INPUT" | jq -e '.stop_hook_active == true' > /dev/null 2>&1; then
-  exit 0
-fi
+# Everything below runs in a background subshell so this hook returns immediately
+# and Claude Code is not blocked waiting for the LLM call to finish.
+#
+# True async requires two things beyond just `&`:
+#
+# 1. Redirect stdin/stdout/stderr away from Claude Code's pipes.
+#    Claude Code captures the hook's output via pipes and waits for EOF on them.
+#    If the background subshell inherits those pipe FDs, Claude Code blocks until
+#    the subshell exits — making `disown` ineffective. Redirecting to /dev/null
+#    and the log file closes the inherited FDs immediately, so Claude Code can
+#    proceed as soon as the hook script exits.
+#
+# 2. disown the background job so the shell doesn't report it on exit.
+{
+  # Acquire a non-blocking lock inside the background block (not before it) so
+  # the hook exits immediately even if another instance is still running.
+  #
+  # This also prevents infinite recursion: running `claude -p` below starts a new
+  # Claude session, which fires another SessionEnd hook when it exits. That nested
+  # hook arrives here, fails flock -n, and exits instantly.
+  exec 9>"$LOCKFILE"
+  if ! flock -n 9; then
+    exit 0
+  fi
 
-TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path')
-SESSION_ID=$(echo "$INPUT" | jq -r '.session_id')
-PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
-FRICTION_DIR="$PROJECT_DIR/.claude/friction"
-TODAY=$(date +%Y-%m-%d)
-SHORT_SESSION=$(echo "$SESSION_ID" | cut -c1-4)
+  TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // empty')
+  SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
+  SHORT_SESSION="${SESSION_ID:0:4}"
+  [ -z "$SHORT_SESSION" ] && SHORT_SESSION="unkn"
 
-# Extract human/assistant messages from the JSONL transcript, truncate each to 2000 chars
-TRANSCRIPT=$(jq -r '
-  select(.role == "user" or .role == "assistant") |
-  "[" + .role + "]: " + (
-    if (.content | type) == "array"
-    then [.content[] | select(.type == "text") | .text] | join(" ")
-    else (.content // "")
+  if [ -z "$TRANSCRIPT_PATH" ]; then
+    log "ERROR: Session $SHORT_SESSION: missing transcript_path in input, cannot proceed"
+    exit 0
+  fi
+
+  log "INFO: Session $SHORT_SESSION: friction capture started"
+  log "DEBUG: transcript_path = $TRANSCRIPT_PATH"
+
+  TODAY=$(date +%Y-%m-%d)
+
+  # The transcript is JSONL. Extract text content from user and assistant turns.
+  # Turns are kept whole — truncating individual turns risks cutting the end of an
+  # assistant response or a user correction, which is exactly where friction lives.
+  # Instead, cap the total at 200K chars by dropping from the front: recent turns
+  # matter most for friction detection, and Haiku's context window is not a concern.
+  TRANSCRIPT=$(jq -r '
+  select(.type == "user" or .type == "assistant") |
+  "[" + .type + "]: " + (
+    if (.message.content | type) == "array"
+    then [.message.content[] | select(.type == "text") | .text] | join(" ")
+    else (.message.content // "")
     end
-  )[:2000]
-' "$TRANSCRIPT_PATH")
+  )
+' "$TRANSCRIPT_PATH" 2>> "$LOG_FILE")
+  TRANSCRIPT="${TRANSCRIPT: -200000}"
 
-mkdir -p "$(dirname "$LOG_FILE")"
+  if [ $? -ne 0 ]; then
+    log "ERROR: Session $SHORT_SESSION: jq failed to parse transcript at $TRANSCRIPT_PATH"
+    exit 0
+  fi
 
-# Skip near-empty sessions
-if [ ${#TRANSCRIPT} -lt 200 ]; then
-  log "Session $SHORT_SESSION: transcript too short, skipping"
-  exit 0
-fi
+  if [ ${#TRANSCRIPT} -lt 200 ]; then
+    log "INFO: Session $SHORT_SESSION: transcript too short (${#TRANSCRIPT} chars), skipping"
+    exit 0
+  fi
 
-# Ask Haiku to identify friction events as a JSON array
-PROMPT="Analyze this coding agent session for friction signals.
+  PROMPT="Analyze this coding agent session for friction signals.
 
 Friction = moments where the human corrected the agent, the agent asked a question
 it shouldn't have needed to ask, the agent made a wrong assumption, or a tool call
@@ -64,42 +111,57 @@ For each friction event found, output a JSON array. Each element must have these
 
 If no friction was found, output an empty array: []
 
-Output ONLY the JSON array, no other text.
+<transcript>
+$TRANSCRIPT
+</transcript>
 
-TRANSCRIPT:
-$TRANSCRIPT"
+Output ONLY valid JSON. Do not use markdown formatting, code fences, or any other text."
 
-log "Session $SHORT_SESSION: analyzing transcript for friction..."
+  # `claude -p` runs a non-interactive prompt using the contributor's local auth.
+  T0=$SECONDS
+  RESULT=$(echo "$PROMPT" | timeout 300 claude -p --model haiku 2>> "$LOG_FILE")
+  CLAUDE_EXIT=$?
 
-# Uses the claude CLI so the hook inherits the contributor's existing auth
-RESULT=$(echo "$PROMPT" | claude -p --model haiku)
+  log "DEBUG: claude took $((SECONDS - T0))s, exit code = $CLAUDE_EXIT, result length = ${#RESULT}"
 
-if [ -z "$RESULT" ] || [ "$RESULT" = "[]" ]; then
-  log "Session $SHORT_SESSION: no friction found"
-  exit 0
-fi
+  if [ $CLAUDE_EXIT -eq 124 ]; then
+    log "ERROR: Session $SHORT_SESSION: claude timed out after 300s"
+    exit 0
+  fi
 
-if ! echo "$RESULT" | jq empty 2>/dev/null; then
-  log "Session $SHORT_SESSION: Haiku returned invalid JSON, skipping"
-  exit 0
-fi
+  if [ $CLAUDE_EXIT -ne 0 ]; then
+    log "ERROR: Session $SHORT_SESSION: claude exited with code $CLAUDE_EXIT"
+    exit 0
+  fi
 
-EVENT_COUNT=$(echo "$RESULT" | jq 'length')
-log "Session $SHORT_SESSION: found $EVENT_COUNT friction event(s)"
+  # Models sometimes wrap JSON in markdown fences despite explicit instructions not to.
+  RESULT=$(echo "$RESULT" | sed '/^```/d')
 
-mkdir -p "$FRICTION_DIR"
+  if [ -z "$RESULT" ] || [ "$RESULT" = "[]" ]; then
+    log "INFO: Session $SHORT_SESSION: no friction found"
+    exit 0
+  fi
 
-# Write one markdown file per friction event
-echo "$RESULT" | jq -c '.[]' | while read -r event; do
-  SLUG=$(echo "$event" | jq -r '.slug // "unknown"')
-  TYPE=$(echo "$event" | jq -r '.type')
-  SEVERITY=$(echo "$event" | jq -r '.severity')
-  DOC_GAP=$(echo "$event" | jq -r '.doc_gap')
-  DESC=$(echo "$event" | jq -r '.description')
+  if ! echo "$RESULT" | jq empty 2>/dev/null; then
+    log "ERROR: Session $SHORT_SESSION: Haiku returned invalid JSON: $(echo "$RESULT" | head -c 200)"
+    exit 0
+  fi
 
-  FILENAME="${TODAY}-${SHORT_SESSION}-${SLUG}.md"
-  log "  -> $FILENAME ($TYPE, $SEVERITY)"
-  cat > "$FRICTION_DIR/$FILENAME" <<EOF
+  EVENT_COUNT=$(echo "$RESULT" | jq 'length')
+  log "INFO: found $EVENT_COUNT friction event(s)"
+
+  # Write one markdown file per friction event with YAML frontmatter.
+  # The /improve-docs skill reads these files to propose documentation changes.
+  echo "$RESULT" | jq -c '.[]' | while read -r event; do
+    SLUG=$(echo "$event" | jq -r '.slug // "unknown"')
+    TYPE=$(echo "$event" | jq -r '.type')
+    SEVERITY=$(echo "$event" | jq -r '.severity')
+    DOC_GAP=$(echo "$event" | jq -r '.doc_gap')
+    DESC=$(echo "$event" | jq -r '.description')
+
+    FILENAME="${TODAY}-${SHORT_SESSION}-${SLUG}.md"
+    log "INFO: -> $FILENAME ($TYPE, $SEVERITY)"
+    cat > "$FRICTION_DIR/$FILENAME" <<EOF
 ---
 type: $TYPE
 severity: $SEVERITY
@@ -111,6 +173,11 @@ date: $TODAY
 
 $DESC
 EOF
-done
+  done
 
-log "Session $SHORT_SESSION: friction capture complete"
+  log "INFO: Session $SHORT_SESSION: friction capture complete"
+
+# Redirect stdin/stdout/stderr so the background subshell does not hold open
+# Claude Code's pipes (see async explanation at the top of the block).
+} </dev/null >>"$LOG_FILE" 2>&1 &
+disown

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,13 +1,13 @@
 {
   "hooks": {
-    "Stop": [
+    "SessionEnd": [
       {
         "matcher": "",
         "hooks": [
           {
             "type": "command",
             "command": "bash .claude/scripts/capture-friction.sh",
-            "timeout": 30000
+            "timeout": 5000
           }
         ]
       }


### PR DESCRIPTION
- Move flock acquisition inside background block so hook exits immediately
- Redirect background subshell stdin/stdout/stderr away from Claude Code's pipes — the real fix for async: disown alone doesn't prevent Claude Code from blocking on pipe EOF
- Replace per-turn 2000-char truncation with a 200K-char total cap, keeping turns whole (corrections and mistakes often live at the end of long turns)
- Increase claude -p timeout from 120s to 300s to match larger input size
- Rename Stop hook references to SessionEnd throughout
- Improve comments and log output