### PR TITLE
docs: improve guidelines from friction capture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,8 @@ Several files are embedded at compile time via `//go:embed`:
 
 Modifying these embedded files changes LLM behavior or report output. Test changes carefully.
 
+`docs/DEMO_CONFIDENCE_REPORT.md` is a rendered example of the report template output. When `internal/report/report_template.md` changes (new fields, section renames, format updates), update this file in the same commit.
+
 ### Two Operation Modes
 
 - **App-interface mode**: Reads a GitLab MR from the `service/app-interface` project, extracts diff URLs from a `devtools-bot` comment, fetches release data from those URLs, and optionally posts the report back to the MR.

--- a/promptfoo.yaml
+++ b/promptfoo.yaml
@@ -117,6 +117,20 @@ tests:
           g.SetLimit(10) to cap concurrency. Uses gCtx (the
           errgroup context) inside goroutines, not the parent ctx.
 
+  # From AGENTS.md: demo file must stay in sync with report template
+  - description: "Report template changes must include update to docs/DEMO_CONFIDENCE_REPORT.md"
+    vars:
+      task: >
+        Add a new "Token Usage" section to the report output template
+        in internal/report/report_template.md that shows the number of
+        input and output tokens consumed by the LLM call.
+    assert:
+      - type: llm-rubric
+        value: >
+          The response mentions updating docs/DEMO_CONFIDENCE_REPORT.md
+          to reflect the new section, either by including the edit or
+          explicitly noting it must be updated in the same commit.
+
   # From integration-guidelines.md: platform parity
   - description: "GitHub changes must consider GitLab parity"
     vars:


### PR DESCRIPTION
  docs: improve guidelines from friction capture

  ## Changes

  - **Missed updating demo file during template format change** (`AGENTS.md`): Added a note to
    the Embedded Files section clarifying that `docs/DEMO_CONFIDENCE_REPORT.md` is a rendered
    example of the report template and must be updated in the same commit when
    `internal/report/report_template.md` changes.
  - **New eval case** (`promptfoo.yaml`): Added a test asserting that an agent responding to a
    report template change task mentions updating `docs/DEMO_CONFIDENCE_REPORT.md`.

  ---

  🤖 Generated with [Claude Code](https://claude.com/claude-code)