### PR TITLE
chore: set up togi (v0.1.0)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,16 @@
 {
+  "enabledPlugins": {
+    "togi@togi": true
+  },
+  "extraKnownMarketplaces": {
+    "togi": {
+      "source": {
+        "source": "github",
+        "repo": "gwenneg/togi"
+      },
+      "autoUpdate": true
+    }
+  },
   "hooks": {
     "SessionStart": [
       {
@@ -6,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/scripts/friction-reminder.sh",
+            "command": ".claude/bin/togi remind",
             "timeout": 2000
           }
         ]
@@ -18,7 +30,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/scripts/friction-capture.sh",
+            "command": ".claude/bin/togi capture",
             "timeout": 5000
           }
         ]

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@
 /.env
 /.promptfoo/
 /rcs
+!/.claude/bin/


### PR DESCRIPTION
## What's in this PR

This PR installs [togi](https://github.com/gwenneg/togi) (研ぎ, to sharpen), a friction-driven feedback loop for AI context docs.

**Installed:**
- `.claude/bin/togi` — the togi binary (v0.1.0), verified via GitHub artifact attestation and SHA-256 checksum
- `.claude/settings.json` — two session hooks (`togi remind` on start, `togi capture` on end), marketplace registration with auto-update enabled, and plugin enablement
- `.gitignore` — togi allowlist entries

**Plugin availability:** The togi plugin is now registered as a marketplace in `.claude/settings.json`. Skills (`/togi:update-context-docs`, `/togi:disable`) are enabled automatically via `enabledPlugins`.

## Enabling friction capture

Friction capture is **disabled by default**.

- **Team-wide:** add `"TOGI_ENABLED": "1"` to `.claude/settings.json`
- **Personal opt-in:** add `"TOGI_ENABLED": "1"` to `.claude/settings.local.json`
- **Personal opt-out:** run `/togi:disable` at any time

You can also set `TOGI_SESSION_THRESHOLD` (default: `3`) to control how many sessions accumulate before the startup reminder appears.

## Data notice

When enabled, up to 200 KB of conversation text is sent to the Anthropic API per session using the developer's existing Claude Code credentials. Tool call outputs (file contents, command output) are excluded. Review `/togi:update-context-docs` PR diffs carefully before merging, as injected content in transcripts could produce friction events targeting arbitrary files.

> **Note:** `togi configure` also deleted several old friction-capture scripts (`.claude/scripts/`, `.claude/skills/disable-friction-capture/`, `.claude/skills/update-context-docs/`) as part of migrating to the togi binary. Those deletions are not included in this PR — a follow-up commit can remove them if desired.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)