### PR TITLE
chore: set up togi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 /.env
 /.promptfoo/
 /rcs
+/.claude/settings.local.json
+/.togi/

--- a/README.md
+++ b/README.md
@@ -228,3 +228,7 @@ These labels are included in the analysis to help assess test coverage and relea
 ### API Rate Limit Optimization
 
 RCS uses in-memory caching to minimize API calls to GitHub and GitLab. When analyzing a release, the same PR/MR objects are often needed for multiple operations (commit enrichment, QE label extraction, user guidance collection). Caching ensures each PR/MR is fetched only once per analysis run, reducing the risk of hitting API rate limits when analyzing releases with many commits.
+
+## AI friction capture (togi)
+
+This repo uses [togi](https://github.com/gwenneg/togi) to turn AI friction into context-doc improvements. Participation is opt-in per developer — see [adopt-togi.md](adopt-togi.md) for the setup commands.

--- a/adopt-togi.md
+++ b/adopt-togi.md
@@ -1,0 +1,12 @@
+# This repo uses togi (研ぎ)
+
+[Togi](https://github.com/gwenneg/togi) turns AI friction — corrections, clarifications, denied tool calls — into context-doc pull requests. Capture is opt-in per developer and runs inside your normal Claude Code session, so it adds no meaningful cost.
+
+To participate, run in Claude Code:
+
+    /plugin marketplace add gwenneg/togi
+    /plugin install togi@togi
+    /reload-plugins
+    /togi:enable
+
+Disable togi any time with /togi:disable. This file is togi's adoption note: it records that this repo adopted togi, and its presence lets togi show a one-time opt-in notice to developers who already have the plugin installed — nothing in this repo installs or runs anything by itself.


### PR DESCRIPTION
Sets up [togi](https://github.com/gwenneg/togi). Every time Claude stumbles in this repo — a wrong assumption, a missing convention, a denied command — that's a gap in our context docs. Togi captures those moments and turns them into doc PRs, so the same stumble doesn't happen twice.

  **Is this safe to merge?** Yes — and you can verify it from the diff alone. The entire change is three inert text files: the adoption note `adopt-togi.md`, a pointer in `README.md`, and `.gitignore` entries. No settings, no hooks, no code: merging installs nothing and runs nothing on anyone's machine. If the diff shows anything beyond those files, reject this PR.

  **Trying it costs a minute.** Run the commands in `adopt-togi.md`, work normally, and check `.togi/friction/pending/` after a few sessions. Capture is opt-in per developer and runs inside your own session — the model writes a short note when it hits friction, nothing is sent to any third party, and there's no meaningful added cost. Haven't opted in? You'll see a one-time notice and nothing else will ever run. Leave any time with `/togi:disable`.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)