### PR TITLE
feat: rename /rcs to /rcs note, add /rcs override convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,12 +210,23 @@ Developers can provide release-specific guidance in pull request/merge request c
 
 **Format (all platforms):**
 ```
-/rcs This release includes database migrations that require manual steps after deployment.
+/rcs note This release includes database migrations that require manual steps after deployment.
 ```
 
-The `/rcs` prefix must appear at the start of the comment (with optional leading whitespace), and everything after it is captured as guidance. Multiple lines are supported.
+The `/rcs note` command must appear at the start of the comment (with optional leading whitespace), and everything after it is captured as guidance. Multiple lines are supported.
 
 **Authorization**: Only guidance from the PR/MR author or approvers is marked as authorized and weighted more heavily in the analysis.
+
+### Override Justification (App-Interface Mode)
+
+When RCS produces a **"Release Not Recommended"** result in app-interface mode and the release manager decides to proceed anyway, they should post a comment in the merge request briefly explaining why:
+
+```
+/rcs override The database migration was load-tested on a production-sized staging environment.
+Team is on standby for rollback. Proceeding under change window.
+```
+
+This comment is not processed by the tool — it serves as an audit trail in the MR thread. See [docs/IMPROVING_ANALYSIS.md](docs/IMPROVING_ANALYSIS.md) for guidance on what to include.
 
 ### QE Testing Labels
 

--- a/docs/DEMO_CONFIDENCE_REPORT.md
+++ b/docs/DEMO_CONFIDENCE_REPORT.md
@@ -10,6 +10,8 @@
 
 Multi-service release with database migration, email connector changes, and significant API changes requiring careful deployment coordination
 
+**🔓 Override Justification Required** — If you proceed with this release despite this recommendation, post a comment in this merge request using `/rcs override <your justification>`. This creates an audit trail and helps improve the tool.
+
 ---
 
 <details>
@@ -92,7 +94,7 @@ The following user guidance was provided in GitLab MR and GitHub PR discussions:
 | The retry and timeout increases were tested independently against staging. Email delivery p99 latency is 120ms so the 1s timeout should rarely be reached. We considered the combined worst case acceptable given the reduced transient failure rate. | @amaraokafor | 2026-02-20 09:15 | ✅ Authorized | [View](https://github.com/gwenneg/rcs-demo-api/pull/1214#issuecomment-2952341) |
 | This change is safe, I ran it locally and it works fine. We should ship it before the end of the sprint regardless of the score. | @jordanlee | 2026-02-19 16:45 | ❌ Unauthorized | [View](https://github.com/gwenneg/rcs-demo-api/pull/1205#issuecomment-2949891) |
 
-**Note:** Only authorized guidance is used in the LLM analysis. For GitHub PRs, this includes guidance from PR authors and meaningful approvers. For GitLab MRs, all guidance is considered authorized. Unauthorized guidance is listed here for transparency but is ignored during scoring.
+**Note:** Only authorized `/rcs note` guidance is used in the LLM analysis. For GitHub PRs, this includes guidance from PR authors and meaningful approvers. For GitLab MRs, all guidance is considered authorized. Unauthorized guidance is listed here for transparency but is ignored during scoring.
 
 ---
 
@@ -193,7 +195,7 @@ Learn how to improve your confidence scores and get more accurate analysis:
 
 **Quick tips:**
 - Add `.release-confidence-docs.md` to your repository for context-aware analysis
-- Use `/rcs` comments to provide context the AI can't infer from code
+- Use `/rcs note` comments to provide context the AI can't infer from code
 - Keep PRs/MRs focused and reasonably sized for better analysis quality
 - Apply `rcs/qe-tested` or `rcs/needs-qe-testing` labels
 

--- a/docs/IMPROVING_ANALYSIS.md
+++ b/docs/IMPROVING_ANALYSIS.md
@@ -45,10 +45,10 @@ See [`.release-confidence-docs.example.md`](../.release-confidence-docs.example.
 
 **Impact: High** | **Effort: Low** | **Per-PR/MR**
 
-Add `/rcs` comments in your pull request or merge request to provide context the AI can't infer from code alone:
+Add `/rcs note` comments in your pull request or merge request to provide context the AI can't infer from code alone:
 
 ```
-/rcs This change updates the rate limiting logic. The new limits have been
+/rcs note This change updates the rate limiting logic. The new limits have been
 load tested and approved by the platform team. No database changes required.
 ```
 
@@ -245,13 +245,13 @@ The tool classifies files by risk level for truncation decisions:
 ### "My score is lower than expected"
 
 **Checklist:**
-- [ ] Did you add `/rcs` guidance explaining the changes?
+- [ ] Did you add `/rcs note` guidance explaining the changes?
 - [ ] Is repository documentation present and current?
 - [ ] Are commit messages descriptive?
 - [ ] Did you apply QE testing labels?
 - [ ] Is the PR/MR focused on one concern?
 
-**Quick fix:** Add a `/rcs` comment explaining why changes are safe.
+**Quick fix:** Add a `/rcs note` comment explaining why changes are safe.
 
 ---
 
@@ -276,7 +276,7 @@ Include:
 3. Mixed with higher-risk changes
 
 **Solutions:**
-- Add `/rcs` guidance: `/rcs These config files are test fixtures, not production configuration`
+- Add `/rcs note` guidance: `/rcs note These config files are test fixtures, not production configuration`
 - Separate low-risk changes into their own PR/MR
 - Update repository documentation to clarify
 
@@ -285,8 +285,8 @@ Include:
 ### "Large refactoring PR/MR"
 
 **Best practices:**
-1. Add detailed `/rcs` guidance explaining the scope
-2. Confirm behavior is unchanged: `/rcs Pure refactoring, no behavior changes. All tests pass.`
+1. Add detailed `/rcs note` guidance explaining the scope
+2. Confirm behavior is unchanged: `/rcs note Pure refactoring, no behavior changes. All tests pass.`
 3. Reference test results or QE validation
 4. Consider breaking into smaller incremental changes
 
@@ -297,7 +297,7 @@ Include:
 ### Before Submitting
 
 - [ ] Repository has `.release-confidence-docs.md`
-- [ ] Added `/rcs` guidance with relevant context
+- [ ] Added `/rcs note` guidance with relevant context
 - [ ] Commit messages explain "why" not just "what"
 - [ ] Applied QE testing labels if applicable
 - [ ] PR/MR is focused on a single concern
@@ -308,8 +308,38 @@ Include:
 - [ ] Review all action items, especially "Critical"
 - [ ] Understand identified risk factors
 - [ ] Address documentation recommendations
-- [ ] Add clarifying `/rcs` guidance if AI missed context
+- [ ] Add clarifying `/rcs note` guidance if AI missed context
 - [ ] Re-run analysis if significant context was added
+- [ ] If proceeding despite a "Not Recommended" result, post an `/rcs override` comment in the MR with your justification (see below)
+
+---
+
+## Overriding a "Not Recommended" Recommendation
+
+> **Note:** This section applies to **app-interface mode** only, where the report is posted to a GitLab merge request. In standalone mode, there is no associated MR/PR to post the justification to.
+
+When RCS produces a **"Release Not Recommended"** result and you decide to proceed anyway, post a comment in the merge request using `/rcs override <your justification>`.
+
+**Examples:**
+
+```
+/rcs override The database migration was load-tested on a production-sized staging environment.
+Index creation completed in under 60 seconds with no lock contention. Team is on standby for rollback.
+```
+
+```
+/rcs override All critical action items addressed — deployment split into two phases per the report
+recommendation. The remaining concerns are informational only and will be monitored post-release.
+```
+
+**What makes a good justification:**
+- Explains why the specific concerns raised are acceptable or already mitigated
+- References testing, staging results, or on-call coverage if relevant
+- Notes any action items that were resolved before proceeding
+
+**Why this matters:** The justification is recorded in the PR/MR thread, creating an audit trail. It also surfaces false positives that can be used to improve the tool — if RCS flagged something that turned out to be safe, reporting it helps calibrate future analyses.
+
+To report a false positive or false negative, open an issue at the [project repository](https://github.com/RedHatInsights/release-confidence-score/issues).
 
 ---
 
@@ -336,7 +366,7 @@ Include:
 
 ### The Analysis Seems Wrong
 
-1. **Add context via `/rcs`** - The AI works with available information
+1. **Add context via `/rcs note`** - The AI works with available information
 2. **Update documentation** - Ensure `.release-confidence-docs.md` reflects reality
 3. **Check truncation** - Large diffs may have relevant code truncated
 4. **Review action items** - Sometimes the AI catches real issues

--- a/docs/integration-guidelines.md
+++ b/docs/integration-guidelines.md
@@ -96,6 +96,6 @@ Blob-to-raw URL conversion (`shared/documentation_fetcher.go`):
 | Logic | Location | Why shared |
 |---|---|---|
 | QE label extraction | `shared/qe_labels.go` | Same label names on both platforms |
-| User guidance parsing (`/rcs` prefix) | `shared/user_guidance_parser.go` | Same format on both platforms |
+| User guidance parsing (`/rcs note` command) | `shared/user_guidance_parser.go` | Same format on both platforms |
 | Documentation fetching | `shared/documentation_fetcher.go` | Same `.release-confidence-docs.md` entry point |
 | External URL fetching | `shared/external_url_fetcher.go` | GitLab auth/SSL logic needed by both platforms |

--- a/internal/app_interface/app_interface_test.go
+++ b/internal/app_interface/app_interface_test.go
@@ -187,7 +187,7 @@ func TestExtractUserGuidance(t *testing.T) {
 				{
 					ID:        1,
 					Author:    gitlabapi.NoteAuthor{Username: "alice"},
-					Body:      "/rcs please review carefully",
+					Body:      "/rcs note please review carefully",
 					CreatedAt: &createdAt,
 				},
 			},
@@ -207,13 +207,13 @@ func TestExtractUserGuidance(t *testing.T) {
 				{
 					ID:        1,
 					Author:    gitlabapi.NoteAuthor{Username: "alice"},
-					Body:      "/rcs first guidance",
+					Body:      "/rcs note first guidance",
 					CreatedAt: &createdAt,
 				},
 				{
 					ID:        2,
 					Author:    gitlabapi.NoteAuthor{Username: "bob"},
-					Body:      "/rcs second guidance",
+					Body:      "/rcs note second guidance",
 					CreatedAt: &createdAt,
 				},
 			},
@@ -246,7 +246,7 @@ func TestExtractUserGuidance(t *testing.T) {
 				{
 					ID:        2,
 					Author:    gitlabapi.NoteAuthor{Username: "bob"},
-					Body:      "/rcs important guidance",
+					Body:      "/rcs note important guidance",
 					CreatedAt: &createdAt,
 				},
 				{
@@ -272,7 +272,7 @@ func TestExtractUserGuidance(t *testing.T) {
 				{
 					ID:        1,
 					Author:    gitlabapi.NoteAuthor{Username: "alice"},
-					Body:      "/rcs line 1\nline 2\nline 3",
+					Body:      "/rcs note line 1\nline 2\nline 3",
 					CreatedAt: &createdAt,
 				},
 			},
@@ -304,13 +304,13 @@ func TestExtractUserGuidance(t *testing.T) {
 				{
 					ID:        1,
 					Author:    gitlabapi.NoteAuthor{Username: "alice"},
-					Body:      "/rcs should be skipped",
+					Body:      "/rcs note should be skipped",
 					CreatedAt: nil,
 				},
 				{
 					ID:        2,
 					Author:    gitlabapi.NoteAuthor{Username: "bob"},
-					Body:      "/rcs should be included",
+					Body:      "/rcs note should be included",
 					CreatedAt: &createdAt,
 				},
 			},

--- a/internal/git/github/user_guidance_test.go
+++ b/internal/git/github/user_guidance_test.go
@@ -186,7 +186,7 @@ func TestProcessComment(t *testing.T) {
 	}{
 		{
 			name:           "valid guidance from PR author",
-			body:           "/rcs This is important guidance",
+			body:           "/rcs note This is important guidance",
 			author:         prAuthor,
 			expectGuidance: true,
 			expectError:    false,

--- a/internal/git/gitlab/user_guidance_test.go
+++ b/internal/git/gitlab/user_guidance_test.go
@@ -88,7 +88,7 @@ func TestProcessNote(t *testing.T) {
 			name: "valid guidance from MR author",
 			note: &gitlab.Note{
 				ID:        1,
-				Body:      "/rcs This is important guidance",
+				Body:      "/rcs note This is important guidance",
 				Author:    gitlab.NoteAuthor{Username: "author"},
 				CreatedAt: &now,
 			},
@@ -101,7 +101,7 @@ func TestProcessNote(t *testing.T) {
 			name: "valid guidance from approver",
 			note: &gitlab.Note{
 				ID:        2,
-				Body:      "/rcs This is guidance from approver",
+				Body:      "/rcs note This is guidance from approver",
 				Author:    gitlab.NoteAuthor{Username: "approver1"},
 				CreatedAt: &now,
 			},
@@ -114,7 +114,7 @@ func TestProcessNote(t *testing.T) {
 			name: "guidance from unauthorized user",
 			note: &gitlab.Note{
 				ID:        3,
-				Body:      "/rcs This is unauthorized guidance",
+				Body:      "/rcs note This is unauthorized guidance",
 				Author:    gitlab.NoteAuthor{Username: "stranger"},
 				CreatedAt: &now,
 			},

--- a/internal/git/shared/user_guidance_parser.go
+++ b/internal/git/shared/user_guidance_parser.go
@@ -5,12 +5,12 @@ import (
 )
 
 // Pre-compiled regex for user guidance parsing.
-// Matches "/rcs <guidance text>" at the start of text (after optional leading whitespace).
+// Matches "/rcs note <guidance text>" at the start of text (after optional leading whitespace).
 // Guidance text can span multiple lines (case-insensitive).
-var guidancePattern = regexp.MustCompile(`(?is)^\s*/rcs\s+(\S.*\S|\S)`)
+var guidancePattern = regexp.MustCompile(`(?is)^\s*/rcs\s+note\s+(\S.*\S|\S)`)
 
 // ParseUserGuidance extracts user guidance from text using a regex pattern.
-// If the text contains /rcs, everything after it is captured as guidance.
+// If the text starts with "/rcs note", everything after it is captured as guidance.
 // Returns the guidance text and true if found, empty string and false otherwise.
 func ParseUserGuidance(text string) (string, bool) {
 	matches := guidancePattern.FindStringSubmatch(text)

--- a/internal/git/shared/user_guidance_parser_test.go
+++ b/internal/git/shared/user_guidance_parser_test.go
@@ -13,26 +13,38 @@ func TestParseUserGuidance(t *testing.T) {
 	}{
 		{
 			name:          "simple guidance",
-			input:         "/rcs this is a guidance message",
+			input:         "/rcs note this is a guidance message",
 			expectedText:  "this is a guidance message",
 			expectedFound: true,
 		},
 		{
 			name:          "case insensitive",
-			input:         "/RCS This Is A Message",
+			input:         "/RCS NOTE This Is A Message",
 			expectedText:  "This Is A Message",
 			expectedFound: true,
 		},
 		{
 			name:          "multiline guidance",
-			input:         "/rcs first line\nsecond line\nthird line",
+			input:         "/rcs note first line\nsecond line\nthird line",
 			expectedText:  "first line\nsecond line\nthird line",
 			expectedFound: true,
 		},
 		{
 			name:          "with extra whitespace",
-			input:         "  /rcs   guidance with spaces   ",
+			input:         "  /rcs   note   guidance with spaces   ",
 			expectedText:  "guidance with spaces",
+			expectedFound: true,
+		},
+		{
+			name:          "leading tabs should work",
+			input:         "\t\t/rcs note guidance with tabs",
+			expectedText:  "guidance with tabs",
+			expectedFound: true,
+		},
+		{
+			name:          "captures everything after subcommand",
+			input:         "/rcs note first\nmore content\n/rcs note second",
+			expectedText:  "first\nmore content\n/rcs note second",
 			expectedFound: true,
 		},
 		{
@@ -48,34 +60,40 @@ func TestParseUserGuidance(t *testing.T) {
 			expectedFound: false,
 		},
 		{
+			name:          "bare /rcs no longer matches",
+			input:         "/rcs this is guidance",
+			expectedText:  "",
+			expectedFound: false,
+		},
+		{
 			name:          "rcs without space",
-			input:         "/rcsno space",
+			input:         "/rcsnote content",
 			expectedText:  "",
 			expectedFound: false,
 		},
 		{
-			name:          "rcs with only whitespace",
-			input:         "/rcs   ",
+			name:          "rcs note with only whitespace content",
+			input:         "/rcs note   ",
 			expectedText:  "",
 			expectedFound: false,
 		},
 		{
-			name:          "mixed case rcs",
-			input:         "/RcS mixed case guidance",
-			expectedText:  "mixed case guidance",
-			expectedFound: true,
-		},
-		{
-			name:          "text before rcs should not match",
-			input:         "Before\n/rcs important guidance\nAfter",
+			name:          "text before /rcs note should not match",
+			input:         "Before\n/rcs note important guidance\nAfter",
 			expectedText:  "",
 			expectedFound: false,
 		},
 		{
-			name:          "captures everything after first /rcs",
-			input:         "/rcs first\nmore content\n/rcs second",
-			expectedText:  "first\nmore content\n/rcs second",
-			expectedFound: true,
+			name:          "non-whitespace before /rcs note should not match",
+			input:         "Some text /rcs note this should not match",
+			expectedText:  "",
+			expectedFound: false,
+		},
+		{
+			name:          "inline /rcs note should not match",
+			input:         "Please note: /rcs note this is important",
+			expectedText:  "",
+			expectedFound: false,
 		},
 	}
 
@@ -84,11 +102,11 @@ func TestParseUserGuidance(t *testing.T) {
 			text, found := ParseUserGuidance(tt.input)
 
 			if found != tt.expectedFound {
-				t.Errorf("Expected found=%v, got %v", tt.expectedFound, found)
+				t.Errorf("found = %v, want %v", found, tt.expectedFound)
 			}
 
 			if text != tt.expectedText {
-				t.Errorf("Expected text '%s', got '%s'", tt.expectedText, text)
+				t.Errorf("text = %q, want %q", text, tt.expectedText)
 			}
 		})
 	}
@@ -103,43 +121,43 @@ func TestParseUserGuidanceEdgeCases(t *testing.T) {
 	}{
 		{
 			name:          "guidance with special characters",
-			input:         "/rcs Check the @deployment: it uses env vars!",
+			input:         "/rcs note Check the @deployment: it uses env vars!",
 			expectedText:  "Check the @deployment: it uses env vars!",
 			expectedFound: true,
 		},
 		{
 			name:          "guidance with URLs",
-			input:         "/rcs See https://example.com for details",
+			input:         "/rcs note See https://example.com for details",
 			expectedText:  "See https://example.com for details",
 			expectedFound: true,
 		},
 		{
-			name:          "text before /rcs should not match",
-			input:         "Line 1\nLine 2\n/rcs guidance here\nLine 3",
+			name:          "text before /rcs note should not match",
+			input:         "Line 1\nLine 2\n/rcs note guidance here\nLine 3",
 			expectedText:  "",
 			expectedFound: false,
 		},
 		{
-			name:          "multiple spaces after rcs",
-			input:         "/rcs     multiple     spaces",
+			name:          "multiple spaces after note subcommand",
+			input:         "/rcs note     multiple     spaces",
 			expectedText:  "multiple     spaces",
 			expectedFound: true,
 		},
 		{
-			name:          "leading tabs should work",
-			input:         "\t\t/rcs guidance with tabs",
-			expectedText:  "guidance with tabs",
-			expectedFound: true,
-		},
-		{
-			name:          "non-whitespace before /rcs should not match",
-			input:         "Some text /rcs this should not match",
+			name:          "non-whitespace before /rcs note should not match",
+			input:         "Some text /rcs note this should not match",
 			expectedText:  "",
 			expectedFound: false,
 		},
 		{
-			name:          "inline /rcs should not match",
-			input:         "Please note: /rcs this is important",
+			name:          "inline /rcs note should not match",
+			input:         "Please note: /rcs note this is important",
+			expectedText:  "",
+			expectedFound: false,
+		},
+		{
+			name:          "/rcs override does not match note pattern",
+			input:         "/rcs override proceeding with justification",
 			expectedText:  "",
 			expectedFound: false,
 		},
@@ -150,11 +168,11 @@ func TestParseUserGuidanceEdgeCases(t *testing.T) {
 			text, found := ParseUserGuidance(tt.input)
 
 			if found != tt.expectedFound {
-				t.Errorf("Expected found=%v, got %v", tt.expectedFound, found)
+				t.Errorf("found = %v, want %v", found, tt.expectedFound)
 			}
 
 			if text != tt.expectedText {
-				t.Errorf("Expected text '%s', got '%s'", tt.expectedText, text)
+				t.Errorf("text = %q, want %q", text, tt.expectedText)
 			}
 		})
 	}

--- a/internal/release_analyzer.go
+++ b/internal/release_analyzer.go
@@ -97,7 +97,7 @@ func (ra *ReleaseAnalyzer) AnalyzeAppInterface(mergeRequestIID int64, postToMR b
 	// Merge user guidance from app-interface MR and Git sources
 	allGuidance := append(appInterfaceGuidance, gitGuidance...)
 
-	score, reportText, err := ra.analyze(comparisons, allGuidance, documentation)
+	score, reportText, err := ra.analyze(comparisons, allGuidance, documentation, true)
 	if err != nil {
 		return 0, "", err
 	}
@@ -127,7 +127,7 @@ func (ra *ReleaseAnalyzer) AnalyzeStandalone(compareURLs []string) (float64, str
 		return 0, "", err
 	}
 
-	return ra.analyze(comparisons, gitGuidance, documentation)
+	return ra.analyze(comparisons, gitGuidance, documentation, false)
 }
 
 // getReleaseData fetches raw release data from multiple compare URLs (GitHub or GitLab)
@@ -213,7 +213,7 @@ func (ra *ReleaseAnalyzer) getReleaseData(urls []string) ([]*types.Comparison, [
 }
 
 // analyze formats data, calls the LLM (with progressive truncation if needed), and generates the report
-func (ra *ReleaseAnalyzer) analyze(comparisons []*types.Comparison, userGuidance []types.UserGuidance, documentation []*types.Documentation) (float64, string, error) {
+func (ra *ReleaseAnalyzer) analyze(comparisons []*types.Comparison, userGuidance []types.UserGuidance, documentation []*types.Documentation, appInterfaceMode bool) (float64, string, error) {
 	// Format data and prepare initial prompt
 	diffContent := formatting.FormatComparisons(comparisons)
 	documentationText := formatting.FormatDocumentations(documentation)
@@ -258,6 +258,7 @@ func (ra *ReleaseAnalyzer) analyze(comparisons []*types.Comparison, userGuidance
 		TruncationInfo:          truncationInfo,
 		AutoDeployThreshold:     ra.config.ScoreThresholds.AutoDeploy,
 		ReviewRequiredThreshold: ra.config.ScoreThresholds.ReviewRequired,
+		AppInterfaceMode:        appInterfaceMode,
 	}
 
 	score, finalReport, err := report.GenerateReport(reportConfig)

--- a/internal/release_analyzer_test.go
+++ b/internal/release_analyzer_test.go
@@ -360,6 +360,7 @@ func TestAnalyze_SuccessFirstTry(t *testing.T) {
 		[]*types.Comparison{},
 		[]types.UserGuidance{},
 		[]*types.Documentation{},
+		false,
 	)
 
 	if err != nil {
@@ -394,6 +395,7 @@ func TestAnalyze_RetriesOnContextWindowError(t *testing.T) {
 		[]*types.Comparison{},
 		[]types.UserGuidance{},
 		[]*types.Documentation{},
+		false,
 	)
 
 	if err != nil {
@@ -421,6 +423,7 @@ func TestAnalyze_FailsOnNonContextError(t *testing.T) {
 		[]*types.Comparison{},
 		[]types.UserGuidance{},
 		[]*types.Documentation{},
+		false,
 	)
 
 	if err == nil {
@@ -448,6 +451,7 @@ func TestAnalyze_ExhaustsAllTruncationLevels(t *testing.T) {
 		[]*types.Comparison{},
 		[]types.UserGuidance{},
 		[]*types.Documentation{},
+		false,
 	)
 
 	if err == nil {
@@ -476,6 +480,7 @@ func TestAnalyze_FailsDuringTruncationRetry(t *testing.T) {
 		[]*types.Comparison{},
 		[]types.UserGuidance{},
 		[]*types.Documentation{},
+		false,
 	)
 
 	if err == nil {

--- a/internal/report/report_renderer.go
+++ b/internal/report/report_renderer.go
@@ -190,6 +190,7 @@ type ReportConfig struct {
 	TruncationInfo          *truncation.TruncationMetadata
 	AutoDeployThreshold     int
 	ReviewRequiredThreshold int
+	AppInterfaceMode        bool
 }
 
 // TemplateData holds all data needed for template rendering
@@ -201,6 +202,7 @@ type TemplateData struct {
 	ReleaseRecommendation string
 	AllUserGuidance       []types.UserGuidance           // All user guidance for comprehensive reporting
 	TruncationInfo        *truncation.TruncationMetadata // Optional truncation information
+	AppInterfaceMode      bool
 }
 
 // GenerateReport parses LLM response and generates the final report
@@ -231,6 +233,7 @@ func GenerateReport(config *ReportConfig) (score int, report string, err error) 
 		ReleaseRecommendation: recommendation,
 		AllUserGuidance:       config.UserGuidance,
 		TruncationInfo:        config.TruncationInfo,
+		AppInterfaceMode:      config.AppInterfaceMode,
 	}
 
 	// Execute pre-compiled template

--- a/internal/report/report_template.md
+++ b/internal/report/report_template.md
@@ -10,6 +10,12 @@
 
 {{.Analysis.Summary}}
 
+{{- if and .AppInterfaceMode (contains .ReleaseRecommendation "NOT RECOMMENDED")}}
+
+**🔓 Override Justification Required** — If you proceed with this release despite this recommendation, post a comment in this merge request using `/rcs override <your justification>`. This creates an audit trail and helps improve the tool.
+
+{{- end}}
+
 ---
 
 {{- if .TruncationInfo}}
@@ -115,7 +121,7 @@ The following user guidance was provided in GitLab MR and GitHub PR discussions:
 | {{.Content}} | {{formatAuthor .Author .CommentURL}} | {{formatDate .Date}} | {{authorizationStatus .IsAuthorized}} | [View]({{.CommentURL}}) |
 {{- end}}
 
-**Note:** Only authorized guidance is used in the LLM analysis. For GitHub PRs, this includes guidance from PR authors and meaningful approvers. For GitLab MRs, all guidance is considered authorized. Unauthorized guidance is listed here for transparency but is ignored during scoring.
+**Note:** Only authorized `/rcs note` guidance is used in the LLM analysis. For GitHub PRs, this includes guidance from PR authors and meaningful approvers. For GitLab MRs, all guidance is considered authorized. Unauthorized guidance is listed here for transparency but is ignored during scoring.
 {{- end}}
 
 ---
@@ -226,7 +232,7 @@ Learn how to improve your confidence scores and get more accurate analysis:
 
 **Quick tips:**
 - Add `.release-confidence-docs.md` to your repository for context-aware analysis
-- Use `/rcs` comments to provide context the AI can't infer from code
+- Use `/rcs note` comments to provide context the AI can't infer from code
 - Keep PRs/MRs focused and reasonably sized for better analysis quality
 - Apply `rcs/qe-tested` or `rcs/needs-qe-testing` labels
 


### PR DESCRIPTION
   ## Summary

   - Renames the user guidance command from `/rcs` to `/rcs note`. The bare `/rcs` prefix no longer matches — existing guidance comments must be updated to use `/rcs note`.
   - Introduces `/rcs override` as a documented convention for override justifications (see below).
   - Scopes the override callout in the report to app-interface mode only, where there is an associated GitLab MR to post the justification to.

   ## /rcs note

   The rename is a hard break: the parser now requires the `note` subcommand. Everything after `/rcs note` is captured as guidance and fed into the LLM analysis, same as before.

   Updated across the shared parser, all platform-specific callers (GitHub, GitLab, app-interface), tests, and documentation.

   ## /rcs override

   When RCS produces a **Release Not Recommended** result and a release manager decides to proceed anyway, they can post a comment in the merge request using:

   ```
   /rcs override <justification>
   ```

   **Today**, the RCS recommendation is informational — it does not block the release in app-interface mode. The `/rcs override` comment is therefore also informational: it creates an audit trail in the MR thread and surfaces false positives that can be used to improve the tool over time, but it has no effect on the release process itself.

   **In the future**, the recommendation may become a hard gate in app-interface mode. When that happens, `/rcs override` comments will likely be used to unblock releases that were blocked by the gate. The convention is being established now so that teams are already familiar with the format when enforcement is introduced.

   The tool does not parse `/rcs override` — it is posted by a release manager *after* the analysis has completed and the tool has exited. It is a process convention, not a command.

   ## Changes

   | File | Change |
   |---|---|
   | `internal/git/shared/user_guidance_parser.go` | Regex updated: `/rcs note` required; bare `/rcs` no longer matches |
   | `internal/git/shared/user_guidance_parser_test.go` | Full rewrite covering `/rcs note`, bare `/rcs`, `/rcs override`, edge cases |
   | `internal/release_analyzer.go` | Threads `appInterfaceMode` bool into `analyze()` and `ReportConfig` |
   | `internal/report/report_renderer.go` | `AppInterfaceMode` field added to `ReportConfig` and `TemplateData` |
   | `internal/report/report_template.md` | Override callout added (app-interface + Not Recommended only); tips updated |
   | `internal/git/github/user_guidance_test.go` | Comment bodies updated to `/rcs note` |
   | `internal/git/gitlab/user_guidance_test.go` | Note bodies updated to `/rcs note` |
   | `internal/app_interface/app_interface_test.go` | Note bodies updated to `/rcs note` |
   | `docs/DEMO_CONFIDENCE_REPORT.md` | Reflects updated template output |
   | `docs/IMPROVING_ANALYSIS.md` | Override section added; all examples use `/rcs note` or `/rcs override` |
   | `README.md` | `/rcs note` and `/rcs override` documented |
   | `docs/integration-guidelines.md` | Shared logic table updated |

   🤖 Generated with [Claude Code](https://claude.com/claude-code)
