### PR TITLE
feat: RHCLOUD-48685 add lifecycle audit logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,28 @@ For Gemini:
 
 See `.env.example` for a complete configuration template.
 
+## Logging
+
+RCS writes structured logs to stdout (see [Logging Configuration](#optional-environment-variables) for format and level options). The following lifecycle entries are produced at the default log level (`info`) for every run:
+
+| Event | Key fields |
+|---|---|
+| Run started | `mode`, `mr_iid` (app-interface) or `compare_urls` (standalone) |
+| LLM call | `provider`, `model_id` |
+| Analysis complete | `score` |
+| Report posted | `mr_iid` (only with `--post-to-mr`) |
+
+Example output with `RCS_LOG_FORMAT=json`:
+
+```json
+{"level":"INFO","msg":"Starting release analysis","mode":"app-interface","mr_iid":42}
+{"level":"INFO","msg":"Calling LLM","provider":"claude","model_id":"claude-sonnet-4-6"}
+{"level":"INFO","msg":"Analysis complete","score":87}
+{"level":"INFO","msg":"Report posted to merge request","mr_iid":42}
+```
+
+Centralization and immutability of logs are the responsibility of the execution environment (e.g., the CI pipeline that runs RCS).
+
 ## How RCS Works
 
 ![How RCS Works](./how-rcs-works.svg)

--- a/internal/release_analyzer.go
+++ b/internal/release_analyzer.go
@@ -74,7 +74,7 @@ func New(cfg *config.Config) (*ReleaseAnalyzer, error) {
 }
 
 func (ra *ReleaseAnalyzer) AnalyzeAppInterface(mergeRequestIID int64, postToMR bool) (float64, string, error) {
-	slog.Debug("Starting release analysis in app-interface mode")
+	slog.Info("Starting release analysis", "mode", "app-interface", "mr_iid", mergeRequestIID)
 
 	// Create GitLab client for app-interface API calls
 	gitlabClient, err := gitlab.NewClient(ra.config)
@@ -115,7 +115,7 @@ func (ra *ReleaseAnalyzer) AnalyzeAppInterface(mergeRequestIID int64, postToMR b
 
 // AnalyzeStandalone performs release analysis using compare URLs directly (standalone mode)
 func (ra *ReleaseAnalyzer) AnalyzeStandalone(compareURLs []string) (float64, string, error) {
-	slog.Debug("Starting release analysis in standalone mode", "url_count", len(compareURLs))
+	slog.Info("Starting release analysis", "mode", "standalone", "compare_urls", compareURLs)
 
 	if len(compareURLs) == 0 {
 		return 0, "", fmt.Errorf("no compare URLs provided")
@@ -224,6 +224,7 @@ func (ra *ReleaseAnalyzer) analyze(comparisons []*types.Comparison, userGuidance
 	}
 
 	// Try LLM analysis with full content first
+	slog.Info("Calling LLM", "provider", ra.config.ModelProvider, "model_id", ra.config.ModelID)
 	response, err := ra.llmClient.Analyze(userPrompt)
 	var truncationInfo *truncation.TruncationMetadata
 
@@ -267,6 +268,7 @@ func (ra *ReleaseAnalyzer) analyze(comparisons []*types.Comparison, userGuidance
 		return 0, "", fmt.Errorf("failed to generate report: %w", err)
 	}
 
+	slog.Info("Analysis complete", "score", score)
 	return float64(score), finalReport, nil
 }
 


### PR DESCRIPTION
## Summary

Addresses the audit logging compliance requirement: RCS must produce log entries covering the complete lifecycle of each run.

Three targeted changes to `internal/release_analyzer.go`:

- Promoted the run-start Debug log to Info in both modes, adding the relevant input parameters (`mr_iid` for app-interface, `compare_urls` for standalone)
- Added an Info entry before the LLM call with `provider` and `model_id`
- Added an Info entry on successful completion with the confidence `score`

At the default log level (`info`), a full run now produces the following lifecycle entries:

```
INFO  Starting release analysis  mode=app-interface  mr_iid=42
INFO  Calling LLM  provider=claude  model_id=claude-sonnet-4-6
INFO  Analysis complete  score=87
INFO  Report posted to merge request  mr_iid=42
```

Also adds a **Logging** section to `README.md` describing the lifecycle entries, an example JSON output, and the note that centralization and immutability are handled by the execution environment.