### PR TITLE
fix: RHCLOUD-49699 prevent GitLab token leakage to attacker-controlled hosts

### DIFF
--- a/internal/git/shared/external_url_fetcher.go
+++ b/internal/git/shared/external_url_fetcher.go
@@ -17,7 +17,7 @@ const httpTimeout = 30 * time.Second
 // fetchExternalURL fetches content from an external URL
 func (d *DocumentationFetcher) fetchExternalURL(ctx context.Context, urlStr string) (string, error) {
 	// Determine if this is a GitLab URL for SSL verification settings
-	isGitLab := isGitLabURL(urlStr)
+	isGitLab := isGitLabURL(urlStr, d.config.GitLabBaseURL)
 	skipSSLVerify := isGitLab && d.config.GitLabSkipSSLVerify
 
 	httpClient := httputil.NewHTTPClient(httputil.HTTPClientOptions{
@@ -53,17 +53,22 @@ func (d *DocumentationFetcher) fetchExternalURL(ctx context.Context, urlStr stri
 	return string(body), nil
 }
 
-// isGitLabURL checks if a URL is a GitLab URL by parsing and examining the hostname
-func isGitLabURL(urlStr string) bool {
-	parsedURL, err := url.Parse(urlStr)
-	if err != nil {
-		// Fallback to simple string matching if parsing fails
-		return strings.Contains(urlStr, "gitlab")
+// isGitLabURL checks if a URL's host exactly matches the configured GitLab instance.
+// Only exact hostname matches are accepted to prevent token leakage to attacker-controlled hosts.
+func isGitLabURL(urlStr, gitlabBaseURL string) bool {
+	if gitlabBaseURL == "" {
+		return false
 	}
 
-	hostname := strings.ToLower(parsedURL.Hostname())
-	// Check for gitlab.com or self-hosted GitLab instances (gitlab.*)
-	return hostname == "gitlab.com" ||
-		hostname == "www.gitlab.com" ||
-		strings.HasPrefix(hostname, "gitlab.")
+	parsedURL, err := url.Parse(urlStr)
+	if err != nil || parsedURL.Hostname() == "" {
+		return false
+	}
+
+	parsedBaseURL, err := url.Parse(gitlabBaseURL)
+	if err != nil || parsedBaseURL.Hostname() == "" {
+		return false
+	}
+
+	return strings.ToLower(parsedURL.Hostname()) == strings.ToLower(parsedBaseURL.Hostname())
 }

--- a/internal/git/shared/external_url_fetcher_test.go
+++ b/internal/git/shared/external_url_fetcher_test.go
@@ -83,41 +83,41 @@ func TestFetchExternalURL_GitLabAuthentication(t *testing.T) {
 	_ = receivedHeader // Avoid unused variable warning
 }
 
-func TestIsGitLabURL_GitLabCom(t *testing.T) {
+func TestIsGitLabURL(t *testing.T) {
 	tests := []struct {
-		url      string
-		expected bool
+		name       string
+		url        string
+		gitlabBase string
+		expected   bool
 	}{
-		{"https://gitlab.com/user/repo", true},
-		{"https://www.gitlab.com/user/repo", true},
-		{"https://gitlab.example.com/user/repo", true},
-		{"https://github.com/user/repo", false},
-		{"https://example.com/user/repo", false},
-		{"https://my-gitlab-server.com/user/repo", false}, // doesn't start with "gitlab."
+		{"configured instance matches", "https://gitlab.corp.example.com/user/repo", "https://gitlab.corp.example.com", true},
+		{"configured instance with path in base", "https://gitlab.corp.example.com/user/repo", "https://gitlab.corp.example.com/api/v4", true},
+		{"case insensitive match", "https://GitLab.Corp.Example.COM/user/repo", "https://gitlab.corp.example.com", true},
+		{"attacker-controlled gitlab prefix", "https://gitlab.evil.example/doc.md", "https://gitlab.corp.example.com", false},
+		{"no base URL configured", "https://gitlab.com/user/repo", "", false},
+		{"github.com", "https://github.com/user/repo", "https://gitlab.corp.example.com", false},
+		{"random domain", "https://example.com/user/repo", "https://gitlab.corp.example.com", false},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.url, func(t *testing.T) {
-			result := isGitLabURL(tt.url)
+		t.Run(tt.name, func(t *testing.T) {
+			result := isGitLabURL(tt.url, tt.gitlabBase)
 			if result != tt.expected {
-				t.Errorf("isGitLabURL(%s) = %v, expected %v", tt.url, result, tt.expected)
+				t.Errorf("isGitLabURL(%s, %s) = %v, expected %v", tt.url, tt.gitlabBase, result, tt.expected)
 			}
 		})
 	}
 }
 
 func TestIsGitLabURL_InvalidURL(t *testing.T) {
-	// Test with invalid URL - url.Parse is very permissive, so let's test actual malformed cases
-	// Most strings parse as relative URLs, so we test the hostname checking instead
 	invalidURL := "://invalid-url-with-gitlab"
-	result := isGitLabURL(invalidURL)
-	// Should fall back to string matching
-	if !result {
-		t.Error("expected true for malformed URL containing 'gitlab'")
+	result := isGitLabURL(invalidURL, "")
+	if result {
+		t.Error("expected false for malformed URL — must not fall back to string matching")
 	}
 
 	noGitLab := "://invalid-url"
-	result = isGitLabURL(noGitLab)
+	result = isGitLabURL(noGitLab, "")
 	if result {
 		t.Error("expected false for malformed URL not containing 'gitlab'")
 	}


### PR DESCRIPTION
## Summary
- **Security fix**: `isGitLabURL()` used `strings.HasPrefix(hostname, "gitlab.")` which matched any host starting with "gitlab." (e.g., `gitlab.evil.example`), and fell back to `strings.Contains` on parse failure — allowing an attacker with commit access to exfiltrate the operator's GitLab PAT via a crafted URL in `.release-confidence-docs.md`.
- Replaced with exact hostname comparison against the configured `GitLabBaseURL`. If the URL can't be parsed or no base URL is configured, credentials are never attached.

## Test plan
- [x] Existing tests updated to cover the attack vector (`gitlab.evil.example` → must return `false`)
- [x] Exact match against configured base URL works (with path, case-insensitive)
- [x] No base URL configured → token never attached
- [x] Malformed URLs → token never attached (no `strings.Contains` fallback)
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)