### PR TITLE
fix: RHCLOUD-49863 cap external URL response body size to 1 MiB

### DIFF
--- a/internal/git/shared/external_url_fetcher.go
+++ b/internal/git/shared/external_url_fetcher.go
@@ -14,6 +14,9 @@ import (
 
 const httpTimeout = 30 * time.Second
 
+// maxResponseBodySize caps the amount of data read from external URLs (1 MiB).
+const maxResponseBodySize = 1 << 20
+
 // fetchExternalURL fetches content from an external URL
 func (d *DocumentationFetcher) fetchExternalURL(ctx context.Context, urlStr string) (string, error) {
 	// Determine if this is a GitLab URL for SSL verification settings
@@ -45,9 +48,14 @@ func (d *DocumentationFetcher) fetchExternalURL(ctx context.Context, urlStr stri
 		return "", fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	limitedReader := io.LimitReader(resp.Body, maxResponseBodySize+1)
+	body, err := io.ReadAll(limitedReader)
 	if err != nil {
 		return "", fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if len(body) > maxResponseBodySize {
+		return "", fmt.Errorf("response body exceeds %d MiB limit", maxResponseBodySize>>20)
 	}
 
 	return string(body), nil

--- a/internal/git/shared/external_url_fetcher_test.go
+++ b/internal/git/shared/external_url_fetcher_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"release-confidence-score/internal/config"
@@ -81,6 +82,30 @@ func TestFetchExternalURL_GitLabAuthentication(t *testing.T) {
 	// Note: This won't actually trigger GitLab auth because the test server URL
 	// doesn't match gitlab.com. We test the logic in isGitLabURL separately.
 	_ = receivedHeader // Avoid unused variable warning
+}
+
+func TestFetchExternalURL_ResponseBodyTooLarge(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		// Write more than maxResponseBodySize (1 MiB)
+		buf := make([]byte, maxResponseBodySize+1)
+		w.Write(buf)
+	}))
+	defer server.Close()
+
+	source := &mockDocumentationSource{}
+	repo := types.Repository{}
+	cfg := &config.Config{}
+	fetcher := NewDocumentationFetcher(source, repo, cfg)
+
+	_, err := fetcher.fetchExternalURL(context.Background(), server.URL)
+
+	if err == nil {
+		t.Fatal("expected error for oversized response body")
+	}
+	if !strings.Contains(err.Error(), "exceeds 1 MiB limit") {
+		t.Errorf("expected error about exceeding limit, got: %v", err)
+	}
 }
 
 func TestIsGitLabURL(t *testing.T) {


### PR DESCRIPTION
## Summary
- Cap `fetchExternalURL` response body to 1 MiB using `io.LimitReader` to prevent OOM from attacker-controlled endpoints
- 1 MiB chosen to stay well above realistic doc sizes while fitting within LLM context window constraints
- Failed fetches surface clearly in the RCS report as "response body exceeds 1 MiB limit"

## Test plan
- [x] New test `TestFetchExternalURL_ResponseBodyTooLarge` verifies oversized responses are rejected
- [x] Existing tests pass — normal-sized responses unaffected
- [x] Full test suite passes (`go test ./...`)

## Jira
[RHCLOUD-49863](https://redhat.atlassian.net/browse/RHCLOUD-49863)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RHCLOUD-49863]: https://redhat.atlassian.net/browse/RHCLOUD-49863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ