### PR TITLE
fix: RHCLOUD-49862 block SSRF to private IPs via external documentation URLs

### DIFF
--- a/internal/git/shared/external_url_fetcher.go
+++ b/internal/git/shared/external_url_fetcher.go
@@ -20,12 +20,20 @@ const maxResponseBodySize = 1 << 20
 // fetchExternalURL fetches content from an external URL
 func (d *DocumentationFetcher) fetchExternalURL(ctx context.Context, urlStr string) (string, error) {
 	// Determine if this is a GitLab URL for SSL verification settings
-	isGitLab := isGitLabURL(urlStr, d.config.GitLabBaseURL)
+	gitlabHost := gitlabHostname(d.config.GitLabBaseURL)
+	isGitLab := isGitLabURL(urlStr, gitlabHost)
 	skipSSLVerify := isGitLab && d.config.GitLabSkipSSLVerify
 
 	httpClient := httputil.NewHTTPClient(httputil.HTTPClientOptions{
-		Timeout:       httpTimeout,
-		SkipSSLVerify: skipSSLVerify,
+		Timeout:         httpTimeout,
+		SkipSSLVerify:   skipSSLVerify,
+		BlockPrivateIPs: true,
+		// The configured GitLab instance is a trusted destination that may
+		// legitimately live on a private IP; anything else comes from
+		// repo-controlled content and must not reach internal infrastructure.
+		// This is checked per dial, so a redirect away from GitLab to another
+		// private host is still blocked.
+		AllowedPrivateHost: gitlabHost,
 	})
 
 	req, err := http.NewRequestWithContext(ctx, "GET", urlStr, nil)
@@ -61,10 +69,11 @@ func (d *DocumentationFetcher) fetchExternalURL(ctx context.Context, urlStr stri
 	return string(body), nil
 }
 
-// isGitLabURL checks if a URL's host exactly matches the configured GitLab instance.
-// Only exact hostname matches are accepted to prevent token leakage to attacker-controlled hosts.
-func isGitLabURL(urlStr, gitlabBaseURL string) bool {
-	if gitlabBaseURL == "" {
+// isGitLabURL checks if a URL's host exactly matches gitlabHost (as returned
+// by gitlabHostname). Only exact hostname matches are accepted to prevent
+// token leakage to attacker-controlled hosts.
+func isGitLabURL(urlStr, gitlabHost string) bool {
+	if gitlabHost == "" {
 		return false
 	}
 
@@ -73,10 +82,16 @@ func isGitLabURL(urlStr, gitlabBaseURL string) bool {
 		return false
 	}
 
+	return strings.ToLower(parsedURL.Hostname()) == gitlabHost
+}
+
+// gitlabHostname returns the lowercase hostname of the configured GitLab
+// instance, or "" if unset or unparsable.
+func gitlabHostname(gitlabBaseURL string) string {
 	parsedBaseURL, err := url.Parse(gitlabBaseURL)
 	if err != nil || parsedBaseURL.Hostname() == "" {
-		return false
+		return ""
 	}
 
-	return strings.ToLower(parsedURL.Hostname()) == strings.ToLower(parsedBaseURL.Hostname())
+	return strings.ToLower(parsedBaseURL.Hostname())
 }

--- a/internal/git/shared/external_url_fetcher_test.go
+++ b/internal/git/shared/external_url_fetcher_test.go
@@ -2,6 +2,7 @@ package shared
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -21,7 +22,11 @@ func TestFetchExternalURL_Success(t *testing.T) {
 
 	source := &mockDocumentationSource{}
 	repo := types.Repository{}
-	cfg := &config.Config{}
+	// GitLabBaseURL matches the test server so it's treated as the trusted
+	// configured instance, bypassing the private-IP SSRF guard (the server
+	// listens on loopback). SSRF blocking itself is covered by
+	// TestFetchExternalURL_BlocksPrivateIPForUntrustedHost below.
+	cfg := &config.Config{GitLabBaseURL: server.URL}
 	fetcher := NewDocumentationFetcher(source, repo, cfg)
 
 	content, err := fetcher.fetchExternalURL(context.Background(), server.URL)
@@ -43,7 +48,7 @@ func TestFetchExternalURL_NotFound(t *testing.T) {
 
 	source := &mockDocumentationSource{}
 	repo := types.Repository{}
-	cfg := &config.Config{}
+	cfg := &config.Config{GitLabBaseURL: server.URL}
 	fetcher := NewDocumentationFetcher(source, repo, cfg)
 
 	_, err := fetcher.fetchExternalURL(context.Background(), server.URL)
@@ -66,22 +71,83 @@ func TestFetchExternalURL_GitLabAuthentication(t *testing.T) {
 	source := &mockDocumentationSource{}
 	repo := types.Repository{}
 	cfg := &config.Config{
-		GitLabToken: "test-token-123",
+		GitLabToken:   "test-token-123",
+		GitLabBaseURL: server.URL, // matches the fetched host, so it's treated as the configured GitLab instance
 	}
 	fetcher := NewDocumentationFetcher(source, repo, cfg)
 
-	// Use gitlab.com URL to trigger GitLab auth
-	gitlabURL := server.URL + "/gitlab-path"
-	// Need to mock this as GitLab URL - let's just test with the server URL
-	// and manually verify token would be set
-	_, err := fetcher.fetchExternalURL(context.Background(), gitlabURL)
+	_, err := fetcher.fetchExternalURL(context.Background(), server.URL)
 
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
-	// Note: This won't actually trigger GitLab auth because the test server URL
-	// doesn't match gitlab.com. We test the logic in isGitLabURL separately.
-	_ = receivedHeader // Avoid unused variable warning
+	if receivedHeader != "test-token-123" {
+		t.Errorf("expected PRIVATE-TOKEN header %q, got: %q", "test-token-123", receivedHeader)
+	}
+}
+
+func TestFetchExternalURL_BlocksPrivateIPForUntrustedHost(t *testing.T) {
+	// Create a test server (listens on loopback, a private/non-public address)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("should never be returned"))
+	}))
+	defer server.Close()
+
+	source := &mockDocumentationSource{}
+	repo := types.Repository{}
+	// No GitLabBaseURL configured (or one that doesn't match), so the target
+	// is treated as untrusted repo-controlled content and must be blocked.
+	cfg := &config.Config{}
+	fetcher := NewDocumentationFetcher(source, repo, cfg)
+
+	_, err := fetcher.fetchExternalURL(context.Background(), server.URL)
+
+	if err == nil {
+		t.Fatal("expected error when fetching an untrusted URL that resolves to a private address")
+	}
+	if !strings.Contains(err.Error(), "blocked") {
+		t.Errorf("expected error about blocked private address, got: %v", err)
+	}
+}
+
+func TestFetchExternalURL_BlocksRedirectFromTrustedHostToPrivateTarget(t *testing.T) {
+	// Simulates a compromised/open-redirect response from the trusted GitLab
+	// host pointing at a different private-only target. The redirect must
+	// still be blocked even though the original request went to a trusted host.
+	internalTarget := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("internal secret"))
+	}))
+	defer internalTarget.Close()
+
+	// Use "localhost" so the redirect target is a distinct literal hostname
+	// from the trusted GitLab server's "127.0.0.1", even though both resolve
+	// to loopback.
+	_, port, err := net.SplitHostPort(strings.TrimPrefix(internalTarget.URL, "http://"))
+	if err != nil {
+		t.Fatalf("failed to split internal target address: %v", err)
+	}
+	redirectTarget := "http://localhost:" + port
+
+	gitlabServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, redirectTarget, http.StatusFound)
+	}))
+	defer gitlabServer.Close()
+
+	source := &mockDocumentationSource{}
+	repo := types.Repository{}
+	cfg := &config.Config{GitLabBaseURL: gitlabServer.URL}
+	fetcher := NewDocumentationFetcher(source, repo, cfg)
+
+	_, err = fetcher.fetchExternalURL(context.Background(), gitlabServer.URL)
+
+	if err == nil {
+		t.Fatal("expected redirect from trusted host to a non-trusted private target to be blocked")
+	}
+	if !strings.Contains(err.Error(), "blocked") {
+		t.Errorf("expected error mentioning blocked address, got: %v", err)
+	}
 }
 
 func TestFetchExternalURL_ResponseBodyTooLarge(t *testing.T) {
@@ -95,7 +161,11 @@ func TestFetchExternalURL_ResponseBodyTooLarge(t *testing.T) {
 
 	source := &mockDocumentationSource{}
 	repo := types.Repository{}
-	cfg := &config.Config{}
+	// GitLabBaseURL matches the test server so it's treated as the trusted
+	// configured instance, bypassing the private-IP SSRF guard (the server
+	// listens on loopback). SSRF blocking itself is covered by
+	// TestFetchExternalURL_BlocksPrivateIPForUntrustedHost above.
+	cfg := &config.Config{GitLabBaseURL: server.URL}
 	fetcher := NewDocumentationFetcher(source, repo, cfg)
 
 	_, err := fetcher.fetchExternalURL(context.Background(), server.URL)
@@ -112,23 +182,22 @@ func TestIsGitLabURL(t *testing.T) {
 	tests := []struct {
 		name       string
 		url        string
-		gitlabBase string
+		gitlabHost string
 		expected   bool
 	}{
-		{"configured instance matches", "https://gitlab.corp.example.com/user/repo", "https://gitlab.corp.example.com", true},
-		{"configured instance with path in base", "https://gitlab.corp.example.com/user/repo", "https://gitlab.corp.example.com/api/v4", true},
-		{"case insensitive match", "https://GitLab.Corp.Example.COM/user/repo", "https://gitlab.corp.example.com", true},
-		{"attacker-controlled gitlab prefix", "https://gitlab.evil.example/doc.md", "https://gitlab.corp.example.com", false},
-		{"no base URL configured", "https://gitlab.com/user/repo", "", false},
-		{"github.com", "https://github.com/user/repo", "https://gitlab.corp.example.com", false},
-		{"random domain", "https://example.com/user/repo", "https://gitlab.corp.example.com", false},
+		{"configured instance matches", "https://gitlab.corp.example.com/user/repo", "gitlab.corp.example.com", true},
+		{"case insensitive match", "https://GitLab.Corp.Example.COM/user/repo", "gitlab.corp.example.com", true},
+		{"attacker-controlled gitlab prefix", "https://gitlab.evil.example/doc.md", "gitlab.corp.example.com", false},
+		{"no host configured", "https://gitlab.com/user/repo", "", false},
+		{"github.com", "https://github.com/user/repo", "gitlab.corp.example.com", false},
+		{"random domain", "https://example.com/user/repo", "gitlab.corp.example.com", false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := isGitLabURL(tt.url, tt.gitlabBase)
+			result := isGitLabURL(tt.url, tt.gitlabHost)
 			if result != tt.expected {
-				t.Errorf("isGitLabURL(%s, %s) = %v, expected %v", tt.url, tt.gitlabBase, result, tt.expected)
+				t.Errorf("isGitLabURL(%s, %s) = %v, expected %v", tt.url, tt.gitlabHost, result, tt.expected)
 			}
 		})
 	}
@@ -148,6 +217,29 @@ func TestIsGitLabURL_InvalidURL(t *testing.T) {
 	}
 }
 
+func TestGitlabHostname(t *testing.T) {
+	tests := []struct {
+		name       string
+		gitlabBase string
+		expected   string
+	}{
+		{"plain host", "https://gitlab.corp.example.com", "gitlab.corp.example.com"},
+		{"path in base is ignored", "https://gitlab.corp.example.com/api/v4", "gitlab.corp.example.com"},
+		{"case is normalized", "https://GitLab.Corp.Example.COM", "gitlab.corp.example.com"},
+		{"empty base", "", ""},
+		{"malformed base", "://invalid-url", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := gitlabHostname(tt.gitlabBase)
+			if result != tt.expected {
+				t.Errorf("gitlabHostname(%s) = %q, expected %q", tt.gitlabBase, result, tt.expected)
+			}
+		})
+	}
+}
+
 func TestFetchAdditionalDocContent_ExternalHTTPURL(t *testing.T) {
 	// Create a test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -158,7 +250,7 @@ func TestFetchAdditionalDocContent_ExternalHTTPURL(t *testing.T) {
 
 	source := &mockDocumentationSource{}
 	repo := types.Repository{}
-	cfg := &config.Config{}
+	cfg := &config.Config{GitLabBaseURL: server.URL}
 	fetcher := NewDocumentationFetcher(source, repo, cfg)
 
 	content, err := fetcher.fetchAdditionalDocContent(context.Background(), "main", server.URL)
@@ -182,7 +274,7 @@ func TestFetchAdditionalDocContent_ExternalHTTPSURL(t *testing.T) {
 
 	source := &mockDocumentationSource{}
 	repo := types.Repository{}
-	cfg := &config.Config{}
+	cfg := &config.Config{GitLabBaseURL: server.URL}
 	fetcher := NewDocumentationFetcher(source, repo, cfg)
 
 	// Test with HTTPS URL prefix detection (using HTTP server for simplicity)
@@ -210,7 +302,7 @@ func TestFetchAdditionalDocContent_BlobURLConversion(t *testing.T) {
 
 	source := &mockDocumentationSource{}
 	repo := types.Repository{}
-	cfg := &config.Config{}
+	cfg := &config.Config{GitLabBaseURL: server.URL}
 	fetcher := NewDocumentationFetcher(source, repo, cfg)
 
 	blobURL := server.URL + "/blob/main/file.md"

--- a/internal/http/httpclient.go
+++ b/internal/http/httpclient.go
@@ -1,8 +1,12 @@
 package http
 
 import (
+	"context"
 	"crypto/tls"
+	"fmt"
+	"net"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -12,6 +16,15 @@ type HTTPClientOptions struct {
 	Timeout time.Duration
 	// SkipSSLVerify disables SSL certificate verification (use with caution)
 	SkipSSLVerify bool
+	// BlockPrivateIPs rejects connections that resolve to private, loopback,
+	// link-local, or otherwise non-public addresses (including cloud metadata
+	// endpoints). Use for requests to attacker-influenced URLs to prevent SSRF.
+	BlockPrivateIPs bool
+	// AllowedPrivateHost, if set, exempts this exact hostname (case-insensitive)
+	// from the private-IP block -- e.g. a configured internal GitLab instance
+	// that may legitimately live on a private IP. The exemption is checked per
+	// dial, so a redirect away from this host to any other host is still blocked.
+	AllowedPrivateHost string
 }
 
 // NewHTTPClient creates an HTTP client with the specified options
@@ -21,13 +34,105 @@ func NewHTTPClient(opts HTTPClientOptions) *http.Client {
 	}
 
 	// Only configure custom transport if SSL verification needs to be skipped
-	if opts.SkipSSLVerify {
-		client.Transport = &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true,
-			},
+	// or private IPs need to be blocked
+	if opts.SkipSSLVerify || opts.BlockPrivateIPs {
+		transport := &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
 		}
+
+		if opts.SkipSSLVerify {
+			transport.TLSClientConfig = &tls.Config{
+				InsecureSkipVerify: true,
+			}
+		}
+
+		if opts.BlockPrivateIPs {
+			transport.DialContext = safeDialContext(opts.AllowedPrivateHost)
+		}
+
+		client.Transport = transport
 	}
 
 	return client
+}
+
+// safeDialContext returns a DialContext that resolves addr and dials only
+// public IP addresses, rejecting private, loopback, link-local, and
+// unspecified ranges, except for an exact match on allowedHost. Validation
+// happens at dial time rather than URL-parse time, so it also covers HTTP
+// redirects (each hop is dialed and checked independently) and cannot be
+// bypassed by DNS rebinding between resolution and connection.
+func safeDialContext(allowedHost string) func(ctx context.Context, network, addr string) (net.Conn, error) {
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid address %q: %w", addr, err)
+		}
+
+		dialer := &net.Dialer{}
+
+		if allowedHost != "" && strings.EqualFold(host, allowedHost) {
+			return dialer.DialContext(ctx, network, addr)
+		}
+
+		ips, err := net.DefaultResolver.LookupIP(ctx, "ip", host)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve host %q: %w", host, err)
+		}
+
+		var lastErr error
+		for _, ip := range ips {
+			if isBlockedIP(ip) {
+				lastErr = fmt.Errorf("connection to %q blocked: resolves to non-public address %s", host, ip)
+				continue
+			}
+
+			conn, err := dialer.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
+			if err == nil {
+				return conn, nil
+			}
+			lastErr = err
+		}
+
+		if lastErr == nil {
+			lastErr = fmt.Errorf("no addresses found for host %q", host)
+		}
+		return nil, lastErr
+	}
+}
+
+// carrierGradeNAT is the RFC 6598 shared address space (100.64.0.0/10), used
+// internally by cloud NAT gateways; net.IP does not classify it as private.
+var carrierGradeNAT = net.IPNet{IP: net.IPv4(100, 64, 0, 0).To4(), Mask: net.CIDRMask(10, 32)}
+
+// nat64Prefix (RFC 6052, 64:ff9b::/96) and ipv4CompatiblePrefix (the
+// deprecated ::a.b.c.d form) both embed an IPv4 address in their low 32 bits,
+// letting an attacker hide a blocked IPv4 target behind an IPv6 literal that
+// net.IP's helpers don't unwrap the way they do for ::ffff:a.b.c.d.
+var (
+	nat64Prefix          = net.IPNet{IP: net.ParseIP("64:ff9b::"), Mask: net.CIDRMask(96, 128)}
+	ipv4CompatiblePrefix = net.IPNet{IP: net.ParseIP("::"), Mask: net.CIDRMask(96, 128)}
+)
+
+// isBlockedIP reports whether ip is a private, loopback, link-local,
+// carrier-grade-NAT, or otherwise non-public address. This includes cloud
+// metadata endpoints (169.254.0.0/16) and IPv4 addresses embedded in an IPv6
+// literal via NAT64 or the deprecated IPv4-compatible form.
+func isBlockedIP(ip net.IP) bool {
+	if isNonPublic(ip) {
+		return true
+	}
+	if nat64Prefix.Contains(ip) || ipv4CompatiblePrefix.Contains(ip) {
+		return isNonPublic(ip.To16()[12:16])
+	}
+	return false
+}
+
+func isNonPublic(ip net.IP) bool {
+	return ip.IsPrivate() ||
+		ip.IsLoopback() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsUnspecified() ||
+		ip.IsMulticast() ||
+		carrierGradeNAT.Contains(ip)
 }

--- a/internal/http/httpclient_test.go
+++ b/internal/http/httpclient_test.go
@@ -2,7 +2,10 @@ package http
 
 import (
 	"crypto/tls"
+	"net"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -133,5 +136,135 @@ func TestNewHTTPClient_TLSConfigValues(t *testing.T) {
 
 	if tlsConfig.InsecureSkipVerify != expected.InsecureSkipVerify {
 		t.Error("InsecureSkipVerify mismatch")
+	}
+}
+
+func TestNewHTTPClient_WithBlockPrivateIPs(t *testing.T) {
+	client := NewHTTPClient(HTTPClientOptions{
+		BlockPrivateIPs: true,
+	})
+
+	if client.Transport == nil {
+		t.Fatal("expected non-nil transport when BlockPrivateIPs is true")
+	}
+
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatal("expected *http.Transport")
+	}
+
+	if transport.DialContext == nil {
+		t.Fatal("expected non-nil DialContext when BlockPrivateIPs is true")
+	}
+}
+
+func TestIsBlockedIP(t *testing.T) {
+	tests := []struct {
+		name     string
+		ip       string
+		expected bool
+	}{
+		{"loopback IPv4", "127.0.0.1", true},
+		{"loopback IPv6", "::1", true},
+		{"private RFC1918 10.x", "10.0.0.5", true},
+		{"private RFC1918 172.16.x", "172.16.0.5", true},
+		{"private RFC1918 192.168.x", "192.168.1.5", true},
+		{"link-local / cloud metadata", "169.254.169.254", true},
+		{"unspecified", "0.0.0.0", true},
+		{"multicast", "224.0.0.1", true},
+		{"public IPv4", "8.8.8.8", false},
+		{"public IPv6", "2001:4860:4860::8888", false},
+		{"carrier-grade NAT", "100.64.0.1", true},
+		{"NAT64-embedded metadata IP", "64:ff9b::169.254.169.254", true},
+		{"NAT64-embedded public IP", "64:ff9b::8.8.8.8", false},
+		{"deprecated IPv4-compatible metadata IP", "::169.254.169.254", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ip := net.ParseIP(tt.ip)
+			if ip == nil {
+				t.Fatalf("failed to parse test IP: %s", tt.ip)
+			}
+			if result := isBlockedIP(ip); result != tt.expected {
+				t.Errorf("isBlockedIP(%s) = %v, expected %v", tt.ip, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNewHTTPClient_BlockPrivateIPs_RejectsLoopback(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient(HTTPClientOptions{BlockPrivateIPs: true})
+
+	// httptest servers listen on loopback (127.0.0.1), which must be blocked
+	_, err := client.Get(server.URL)
+	if err == nil {
+		t.Fatal("expected error when connecting to loopback address with BlockPrivateIPs enabled")
+	}
+	if !strings.Contains(err.Error(), "blocked") {
+		t.Errorf("expected error mentioning blocked address, got: %v", err)
+	}
+}
+
+func TestNewHTTPClient_AllowedPrivateHost_BypassesBlockForExactHost(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	_, port, err := net.SplitHostPort(strings.TrimPrefix(server.URL, "http://"))
+	if err != nil {
+		t.Fatalf("failed to split test server address: %v", err)
+	}
+
+	client := NewHTTPClient(HTTPClientOptions{
+		BlockPrivateIPs:    true,
+		AllowedPrivateHost: "localhost",
+	})
+
+	resp, err := client.Get("http://localhost:" + port)
+	if err != nil {
+		t.Fatalf("expected allowed host to bypass the private-IP block, got: %v", err)
+	}
+	resp.Body.Close()
+}
+
+func TestNewHTTPClient_AllowedPrivateHost_StillBlocksOtherHosts(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient(HTTPClientOptions{
+		BlockPrivateIPs:    true,
+		AllowedPrivateHost: "localhost",
+	})
+
+	// server.URL is http://127.0.0.1:PORT -- a different literal hostname than
+	// the allowed "localhost", even though both resolve to loopback. This is
+	// what protects a trusted host's redirect from reaching an unrelated
+	// private target: only the exact allowed hostname is exempted.
+	_, err := client.Get(server.URL)
+	if err == nil {
+		t.Fatal("expected a non-allowed host on a private address to be blocked")
+	}
+	if !strings.Contains(err.Error(), "blocked") {
+		t.Errorf("expected error mentioning blocked address, got: %v", err)
+	}
+}
+
+func TestNewHTTPClient_UsesEnvironmentProxy(t *testing.T) {
+	client := NewHTTPClient(HTTPClientOptions{BlockPrivateIPs: true})
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatal("expected *http.Transport")
+	}
+	if transport.Proxy == nil {
+		t.Fatal("expected Proxy to be set so HTTP_PROXY/HTTPS_PROXY env vars are honored")
 	}
 }


### PR DESCRIPTION
## Summary
- Add `BlockPrivateIPs` option to `NewHTTPClient` that validates the resolved IP at **dial time** (not URL-parse time), rejecting private/RFC1918, loopback, link-local (covers the `169.254.169.254` cloud metadata endpoint), carrier-grade NAT (RFC 6598, `100.64.0.0/10`), and IPv4 addresses hidden inside an IPv6 literal via NAT64 (`64:ff9b::/96`) or the deprecated IPv4-compatible (`::a.b.c.d`) form
- Dial-time validation applies to every connection attempt including HTTP redirects (each hop is dialed and checked independently), and can't be bypassed by DNS rebinding between resolution and connection
- `fetchExternalURL` enables this guard unconditionally for every request. A new `AllowedPrivateHost` option exempts only the exact configured GitLab hostname (case-insensitive), since that host is trusted config and may legitimately sit on a private IP in enterprise deployments (e.g. `gitlab.cee.redhat.com`). The exemption is checked per dial, so a redirect from the trusted GitLab host to any other host is still blocked — it does not disable the guard for the whole request/redirect chain
- The custom `Transport` now also sets `Proxy: http.ProxyFromEnvironment`, matching `http.DefaultTransport`, so `HTTP_PROXY`/`HTTPS_PROXY` continue to be honored on the paths that build a custom transport (previously silently dropped)

## Test plan
- [x] `TestIsBlockedIP` table test covers private/loopback/link-local/metadata/multicast/CGNAT/NAT64-embedded/IPv4-compatible-embedded/public IPv4+IPv6
- [x] `TestNewHTTPClient_BlockPrivateIPs_RejectsLoopback` verifies the dialer wiring end-to-end
- [x] `TestNewHTTPClient_AllowedPrivateHost_BypassesBlockForExactHost` / `_StillBlocksOtherHosts` verify the exemption is scoped to the exact hostname, not the whole client
- [x] `TestNewHTTPClient_UsesEnvironmentProxy` verifies proxy env vars are honored
- [x] `TestFetchExternalURL_BlocksPrivateIPForUntrustedHost` verifies an untrusted URL resolving to a private address is rejected
- [x] `TestFetchExternalURL_BlocksRedirectFromTrustedHostToPrivateTarget` verifies a redirect from the trusted GitLab host to a different, non-trusted private host is still blocked
- [x] `TestGitlabHostname` / updated `TestIsGitLabURL` cover hostname extraction and matching
- [x] Existing fetch tests updated to configure `GitLabBaseURL` matching the test server, since they exercise fetch mechanics (success/404/auth/blob-URL conversion/body-size limit) rather than SSRF blocking
- [x] Full test suite passes (`go test ./...`), `go vet ./...` clean

## Jira
[RHCLOUD-49862](https://redhat.atlassian.net/browse/RHCLOUD-49862)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[RHCLOUD-49862]: https://redhat.atlassian.net/browse/RHCLOUD-49862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ