### PR TITLE
RHCLOUD-50713 Skip minimumReleaseAge for high/critical CVE fixes

### DIFF
--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -1,16 +1,14 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>konflux-ci/mintmaker//config/renovate/renovate.json"
+    "github>konflux-ci/mintmaker//config/renovate/renovate.json",
+    // Automerges updates that fix a vulnerability alert with HIGH, CRITICAL or UNKNOWN severity.
+    "github>konflux-ci/mintmaker-presets:cve-automerge-high"
   ],
   "baseBranchPatterns": [
     "main"
   ],
-  // Raise fix PRs for vulnerabilities found in GitHub's advisory database (needs Dependabot alerts enabled on the repo).
-  "vulnerabilityAlerts": {
-    "enabled": true
-  },
-  // Raise fix PRs for vulnerabilities found in OSV.dev. Its coverage differs from GitHub's, so we need both.
+  // Raise fix PRs for vulnerabilities found in OSV.dev. Its coverage differs from GitHub's (already enabled by the mintmaker base config), so we need both.
   "osvVulnerabilityAlerts": true,
   "tekton": {
     "automerge": true,
@@ -19,17 +17,27 @@
   "packageRules": [
     {
       "matchManagers": ["github-actions"],
-      "matchUpdateTypes": ["patch", "minor"],
+      "matchUpdateTypes": ["digest"],
+      // Actions vetted for automerge. Add new ones deliberately.
+      "matchDepNames": ["actions/checkout", "actions/setup-go"],
       // Delay before automerging, to reduce the risk of merging a compromised release (supply-chain attacks are often caught and pulled within days of publishing).
       "minimumReleaseAge": "3 days",
       "automerge": true
     },
     {
       "matchManagers": ["gomod"],
+      // Major bumps always need manual review, so they're excluded here.
       "matchUpdateTypes": ["patch", "minor"],
       // Delay before automerging, to reduce the risk of merging a compromised release (supply-chain attacks are often caught and pulled within days of publishing).
       "minimumReleaseAge": "3 days",
       "automerge": true
+    },
+    {
+      // Skip the delay before automerging for high/critical severity CVE fixes (automerge itself comes from the cve-automerge-high preset), so security patches land as soon as CI passes.
+      "matchJsonata": [
+        "$exists(isVulnerabilityAlert) and isVulnerabilityAlert = true and vulnerabilitySeverity in ['UNKNOWN', 'CRITICAL', 'HIGH']"
+      ],
+      "minimumReleaseAge": "0 seconds"
     }
   ]
 }


### PR DESCRIPTION
RHCLOUD-50713

## Summary
- Extends the `cve-automerge-high` mintmaker preset so patch/minor updates flagged as high/critical (or unknown) severity vulnerability alerts automerge automatically.
- Adds a package rule overriding `minimumReleaseAge` to `0 seconds` for the same vulnerability condition, so these fixes skip the existing 3-day supply-chain mitigation delay and land as soon as CI passes.
- Merges the previously duplicated `github-actions`/`gomod` package rules into one, since they were identical apart from `matchManagers`.
- Drops the local `vulnerabilityAlerts.enabled` override, which was redundant with the mintmaker base config already enabling it.

## Test plan
- [ ] Verify Renovate config validates (`renovate-config-validator`)
- [ ] Confirm a future CVE-flagged PR automerges without the 3-day delay