### PR TITLE
Don't automerge GitHub Actions digest-only updates

### DIFF
--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -17,7 +17,9 @@
   "packageRules": [
     {
       "matchManagers": ["github-actions"],
-      "matchUpdateTypes": ["digest"],
+      // Excludes digest-only updates, so a hijacked tag re-pointed to a malicious commit
+      // with no version delta never gets automerged.
+      "matchUpdateTypes": ["patch", "minor"],
       // Actions vetted for automerge. Add new ones deliberately.
       "matchDepNames": ["actions/checkout", "actions/setup-go"],
       // Delay before automerging, to reduce the risk of merging a compromised release (supply-chain attacks are often caught and pulled within days of publishing).


### PR DESCRIPTION
## Summary
- The GitHub Actions automerge rule matched `matchUpdateTypes: ["digest"]`, but Renovate classifies SHA-pinned actions with a semver tag comment as `patch`/`minor` updates when the tag changes, not `digest` — so the rule never actually matched real version bumps.
- We don't want the reverse either: a digest-only change with no version delta should never be eligible for automerge, since there's no changelog/version signal to catch a hijacked tag re-pointed to a malicious commit.
- Restricts the vetted-actions automerge rule to `["patch", "minor"]` only, excluding digest-only updates entirely.

## Test plan
- [ ] Confirm Renovate/Mintmaker picks up the new `renovate.jsonc` and future patch/minor PRs for the vetted actions still automerge after the 3-day `minimumReleaseAge` window
- [ ] Confirm a hypothetical digest-only PR (same tag, new SHA) for one of the vetted actions is not automerged